### PR TITLE
Makefile: fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ script:
   - make all-cover
 
 after_script:
-  - make codecov codeclimate EXIT_CODE=$TRAVIS_TEST_RESULT
+  - make cover-upload EXIT_CODE=$TRAVIS_TEST_RESULT

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ format:
 
 .PHONY: codecov
 codecov: PROFILEFILE=coverage.txt
+codecov: SHELL=/bin/bash
 codecov: test-cover
 codecov:
 	bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ codecov:
 .PHONY: codeclimate-prepare
 codeclimate-prepare:
 	cc-test-reporter before-build
-\
+
 .PHONY: codeclimate
 codeclimate: PROFILEFILE=c.out
 codeclimate: codeclimate-prepare test-cover

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,12 @@ codeclimate: codeclimate-prepare test-cover
 codeclimate:
 	env CC_TEST_REPORTER_ID=$(CC_TEST_REPORTER_ID) cc-test-reporter after-build --exit-code $(EXIT_CODE)
 
+.PHONY: cover-upload
+cover-upload: codecov
+	# Make codeclimate as command, as we need to run test-cover twice and make deduplicates that.
+	# Go test results are cached anyway, so it's fine to run it multiple times.
+	make codeclimate
+
 .PHONY: install-golangci-lint
 install-golangci-lint:
 	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(BIN_PATH) $(GOLANGCI_LINT_VERSION)


### PR DESCRIPTION
It requires bash to run anyway, but without this, target is interpreted
with sh, which results in following error:

```console
sh: -c: line 0: syntax error near unexpected token `('
sh: -c: line 0: `bash <(curl -s https://codecov.io/bash)'
```

This also means, that codecov fails to run in the CI right now and this
commit fixes that.

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>