### PR TITLE
internal/util: add JoinSorted helper method

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -26,7 +26,7 @@ func PickInt(values ...int) int {
 	return 0
 }
 
-// Indent indents a block of text with an indent string
+// Indent indents a block of text with an indent string.
 func Indent(text, indent string) string {
 	if text[len(text)-1:] == "\n" {
 		result := ""

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -44,4 +46,23 @@ func Indent(text, indent string) string {
 	}
 
 	return result[:len(result)-1]
+}
+
+// JoinSorted takes map of keys and values, sorts them by keys and joins with given separators.
+func JoinSorted(values map[string]string, valueSeparator string, keySeparator string) string {
+	keys := []string{}
+
+	for k := range values {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	v := []string{}
+
+	for _, k := range keys {
+		v = append(v, fmt.Sprintf("%s%s%s", k, valueSeparator, values[k]))
+	}
+
+	return strings.Join(v, keySeparator)
 }

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -56,3 +56,16 @@ func TestIndentWithNewline(t *testing.T) {
 		t.Fatalf("expected '%s', got '%s'", expected, a)
 	}
 }
+
+func TestJoinSorted(t *testing.T) {
+	expected := "baz/doh|foo/bar"
+
+	values := map[string]string{
+		"foo": "bar",
+		"baz": "doh",
+	}
+
+	if a := JoinSorted(values, "/", "|"); a != expected {
+		t.Fatalf("expected '%s', got '%s'", expected, a)
+	}
+}


### PR DESCRIPTION
This will be used for example in kubelet, when user provices labels and
taints as map and we need to convert them to string.

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>