### PR TITLE
pkg/container/runtime/docker: improvements

### DIFF
--- a/pkg/container/runtime/docker/docker.go
+++ b/pkg/container/runtime/docker/docker.go
@@ -23,23 +23,23 @@ import (
 	"github.com/flexkube/libflexkube/pkg/defaults"
 )
 
-// Config struct represents Docker container runtime configuration
+// Config struct represents Docker container runtime configuration.
 type Config struct {
 	Host string `json:"host,omitempty" yaml:"host,omitempty"`
 }
 
-// docker struct is a struct, which can be used to manage Docker containers
+// docker struct is a struct, which can be used to manage Docker containers.
 type docker struct {
 	ctx context.Context
 	cli *client.Client
 }
 
-// SetAddress sets runtime config address where it should connect
+// SetAddress sets runtime config address where it should connect.
 func (c *Config) SetAddress(s string) {
 	c.Host = s
 }
 
-// GetAddress returns configured container runtime address
+// GetAddress returns configured container runtime address.
 func (c *Config) GetAddress() string {
 	if c != nil && c.Host != "" {
 		return c.Host
@@ -70,7 +70,7 @@ func (c *Config) New() (runtime.Runtime, error) {
 	}, nil
 }
 
-// Start starts Docker container
+// Start starts Docker container.
 func (d *docker) Create(config *types.ContainerConfig) (string, error) {
 	// Pull image to make sure it's available.
 	// TODO make it configurable?
@@ -139,7 +139,7 @@ func (d *docker) Create(config *types.ContainerConfig) (string, error) {
 		},
 	}
 
-	// Create container
+	// Create container.
 	c, err := d.cli.ContainerCreate(d.ctx, &dockerConfig, &hostConfig, &network.NetworkingConfig{}, config.Name)
 	if err != nil {
 		return "", fmt.Errorf("creating container: %w", err)
@@ -148,23 +148,23 @@ func (d *docker) Create(config *types.ContainerConfig) (string, error) {
 	return c.ID, nil
 }
 
-// Start starts Docker container
+// Start starts Docker container.
 func (d *docker) Start(id string) error {
 	return d.cli.ContainerStart(d.ctx, id, dockertypes.ContainerStartOptions{})
 }
 
-// Stop stops Docker container
+// Stop stops Docker container.
 func (d *docker) Stop(id string) error {
 	// TODO make this configurable?
 	timeout := time.Duration(30) * time.Second
 	return d.cli.ContainerStop(d.ctx, id, &timeout)
 }
 
-// Status returns container status
+// Status returns container status.
 func (d *docker) Status(id string) (*types.ContainerStatus, error) {
 	status, err := d.cli.ContainerInspect(d.ctx, id)
 	if err != nil {
-		// If container is missing, return no status
+		// If container is missing, return no status.
 		if client.IsErrNotFound(err) {
 			return nil, nil
 		}
@@ -180,7 +180,7 @@ func (d *docker) Status(id string) (*types.ContainerStatus, error) {
 	}, nil
 }
 
-// Delete removes the container
+// Delete removes the container.
 func (d *docker) Delete(id string) error {
 	return d.cli.ContainerRemove(d.ctx, id, dockertypes.ContainerRemoveOptions{})
 }
@@ -233,7 +233,7 @@ func (d *docker) Stat(id string, paths []string) (map[string]*os.FileMode, error
 	return result, nil
 }
 
-// Read reads files from container
+// Read reads files from container.
 func (d *docker) Read(id string, srcPaths []string) ([]*types.File, error) {
 	files := []*types.File{}
 

--- a/pkg/container/runtime/docker/docker_integration_test.go
+++ b/pkg/container/runtime/docker/docker_integration_test.go
@@ -8,35 +8,26 @@ import (
 
 	dockertypes "github.com/docker/docker/api/types"
 
+	"github.com/flexkube/libflexkube/pkg/container/runtime"
 	"github.com/flexkube/libflexkube/pkg/container/types"
 	"github.com/flexkube/libflexkube/pkg/defaults"
 )
 
 // Create
 func TestContainerCreate(t *testing.T) {
-	dc := &Config{}
-
-	r, err := dc.New()
-	if err != nil {
-		t.Errorf("Creating new docker runtime should succeed, got: %s", err)
-	}
+	r, _ := getDockerRuntime(t)
 
 	cc := &types.ContainerConfig{
 		Image: defaults.EtcdImage,
 	}
 
-	if _, err = r.Create(cc); err != nil {
+	if _, err := r.Create(cc); err != nil {
 		t.Errorf("Creating container should succeed, got: %s", err)
 	}
 }
 
 func TestContainerCreateDelete(t *testing.T) {
-	dc := &Config{}
-
-	r, err := dc.New()
-	if err != nil {
-		t.Errorf("Creating new docker runtime should succeed, got: %s", err)
-	}
+	r, _ := getDockerRuntime(t)
 
 	cc := &types.ContainerConfig{
 		Image: defaults.EtcdImage,
@@ -53,18 +44,13 @@ func TestContainerCreateDelete(t *testing.T) {
 }
 
 func TestContainerCreateNonExistingImage(t *testing.T) {
-	dc := &Config{}
-
-	r, err := dc.New()
-	if err != nil {
-		t.Errorf("Creating new docker runtime should succeed, got: %s", err)
-	}
+	r, _ := getDockerRuntime(t)
 
 	cc := &types.ContainerConfig{
 		Image: "nonexistingimage",
 	}
 
-	if _, err = r.Create(cc); err == nil {
+	if _, err := r.Create(cc); err == nil {
 		t.Errorf("Creating container with non-existing image should fail")
 	}
 }
@@ -73,14 +59,7 @@ func TestContainerCreatePullImage(t *testing.T) {
 	// Don't use default version of image, to have better chance it can be removed
 	image := "gcr.io/etcd-development/etcd:v3.3.0"
 
-	dc := &Config{}
-
-	r, err := dc.New()
-	if err != nil {
-		t.Errorf("Creating new docker runtime should succeed, got: %s", err)
-	}
-
-	d := (r.(*docker))
+	r, d := getDockerRuntime(t)
 
 	images, err := d.cli.ImageList(d.ctx, dockertypes.ImageListOptions{})
 	if err != nil {
@@ -114,12 +93,7 @@ func TestContainerCreatePullImage(t *testing.T) {
 func TestContainerCreateWithArgs(t *testing.T) {
 	args := []string{"--logger=zap"}
 
-	dc := &Config{}
-
-	r, err := dc.New()
-	if err != nil {
-		t.Errorf("Creating new docker runtime should succeed, got: %s", err)
-	}
+	r, d := getDockerRuntime(t)
 
 	c := &types.ContainerConfig{
 		Image:      defaults.EtcdImage,
@@ -131,8 +105,6 @@ func TestContainerCreateWithArgs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Creating container with args should succeed, got: %v", err)
 	}
-
-	d := (r.(*docker))
 
 	data, err := d.cli.ContainerInspect(d.ctx, id)
 	if err != nil {
@@ -147,12 +119,7 @@ func TestContainerCreateWithArgs(t *testing.T) {
 func TestContainerCreateWithEntrypoint(t *testing.T) {
 	entrypoint := []string{"/bin/bash"}
 
-	dc := &Config{}
-
-	r, err := dc.New()
-	if err != nil {
-		t.Errorf("Creating new docker runtime should succeed, got: %s", err)
-	}
+	r, d := getDockerRuntime(t)
 
 	c := &types.ContainerConfig{
 		Image:      defaults.EtcdImage,
@@ -163,8 +130,6 @@ func TestContainerCreateWithEntrypoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Creating container with entrypoint should succeed, got: %v", err)
 	}
-
-	d := (r.(*docker))
 
 	data, err := d.cli.ContainerInspect(d.ctx, id)
 	if err != nil {
@@ -178,12 +143,7 @@ func TestContainerCreateWithEntrypoint(t *testing.T) {
 
 // Start()
 func TestContainerStart(t *testing.T) {
-	dc := &Config{}
-
-	r, err := dc.New()
-	if err != nil {
-		t.Errorf("Creating new docker runtime should succeed, got: %s", err)
-	}
+	r, _ := getDockerRuntime(t)
 
 	c := &types.ContainerConfig{
 		Image: defaults.EtcdImage,
@@ -201,12 +161,7 @@ func TestContainerStart(t *testing.T) {
 
 // Stop()
 func TestContainerStop(t *testing.T) {
-	dc := &Config{}
-
-	r, err := dc.New()
-	if err != nil {
-		t.Errorf("Creating new docker runtime should succeed, got: %s", err)
-	}
+	r, _ := getDockerRuntime(t)
 
 	c := &types.ContainerConfig{
 		Image: defaults.EtcdImage,
@@ -228,12 +183,7 @@ func TestContainerStop(t *testing.T) {
 
 // Status()
 func TestContainerStatus(t *testing.T) {
-	dc := &Config{}
-
-	r, err := dc.New()
-	if err != nil {
-		t.Errorf("Creating new docker runtime should succeed, got: %s", err)
-	}
+	r, _ := getDockerRuntime(t)
 
 	c := &types.ContainerConfig{
 		Image: defaults.EtcdImage,
@@ -250,12 +200,7 @@ func TestContainerStatus(t *testing.T) {
 }
 
 func TestContainerStatusNonExistent(t *testing.T) {
-	dc := &Config{}
-
-	r, err := dc.New()
-	if err != nil {
-		t.Errorf("Creating new docker runtime should succeed, got: %s", err)
-	}
+	r, _ := getDockerRuntime(t)
 
 	status, err := r.Status("nonexistent")
 	if err != nil {
@@ -265,4 +210,15 @@ func TestContainerStatusNonExistent(t *testing.T) {
 	if status != nil {
 		t.Errorf("Getting non-existent container status shouldn't return any status")
 	}
+}
+
+func getDockerRuntime(t *testing.T) (runtime.Runtime, *docker) {
+	dc := &Config{}
+
+	r, err := dc.New()
+	if err != nil {
+		t.Fatalf("Creating new docker runtime should succeed, got: %s", err)
+	}
+
+	return r, (r.(*docker))
 }

--- a/pkg/container/runtime/docker/docker_integration_test.go
+++ b/pkg/container/runtime/docker/docker_integration_test.go
@@ -61,20 +61,7 @@ func TestContainerCreatePullImage(t *testing.T) {
 
 	r, d := getDockerRuntime(t)
 
-	images, err := d.cli.ImageList(d.ctx, dockertypes.ImageListOptions{})
-	if err != nil {
-		t.Fatalf("Listing docker images should succeed, got: %v", err)
-	}
-
-	for _, i := range images {
-		for _, tag := range i.RepoTags {
-			if tag == image {
-				if _, err := d.cli.ImageRemove(d.ctx, i.ID, dockertypes.ImageRemoveOptions{}); err != nil {
-					t.Fatalf("Removing existing docker image should succeed, got: %v", err)
-				}
-			}
-		}
-	}
+	deleteImage(t, image)
 
 	c := &types.ContainerConfig{
 		Image: image,


### PR DESCRIPTION
This PR cleans up `docker` package a bit and changes way Docker runtime pulls images when creating containers. Now images will only be pulled if they are not present on a target host. That speeds up the process of deployments/updates and also make it work in offline environments.