### PR TITLE
pkg/container/hostconfiguredcontainer: add support for hooks

### DIFF
--- a/pkg/container/containers.go
+++ b/pkg/container/containers.go
@@ -252,53 +252,20 @@ func FromYaml(c []byte) (*containers, error) {
 	return cl, nil
 }
 
-func (c *containers) CurrentStateToExported() *Containers {
-	containers := &Containers{
-		PreviousState: ContainersState{},
-	}
-	for i, m := range c.currentState {
-		containers.PreviousState[i] = &HostConfiguredContainer{
-			Container:   m.container,
-			Host:        m.host,
-			ConfigFiles: m.configFiles,
-		}
-	}
-
-	return containers
-}
-
+// CurrentStateToYaml dumps current state as previousState in exported format,
+// which can be serialized and stored.
 func (c *containers) CurrentStateToYaml() ([]byte, error) {
-	return yaml.Marshal(c.CurrentStateToExported())
-}
-
-func (c *containers) DesiredStateToExported() *Containers {
 	containers := &Containers{
-		DesiredState: ContainersState{},
-	}
-	for i, m := range c.desiredState {
-		containers.DesiredState[i] = &HostConfiguredContainer{
-			Container:   m.container,
-			Host:        m.host,
-			ConfigFiles: m.configFiles,
-		}
+		PreviousState: c.previousState.Export(),
 	}
 
-	return containers
+	return yaml.Marshal(containers)
 }
 
-func (c *containers) DesiredStateToYAML() ([]byte, error) {
-	return yaml.Marshal(c.DesiredStateToExported())
-}
-
+// ToExported converts containers struct to exported Containers.
 func (c *containers) ToExported() *Containers {
-	ccs := c.CurrentStateToExported()
-	ds := c.DesiredStateToExported()
-	ccs.DesiredState = ds.DesiredState
-
-	return ccs
-}
-
-// ToYaml allows to dump containers state to YAML, so it can be restored later.
-func (c *containers) ToYaml() ([]byte, error) {
-	return yaml.Marshal(c.ToExported())
+	return &Containers{
+		PreviousState: c.previousState.Export(),
+		DesiredState:  c.desiredState.Export(),
+	}
 }

--- a/pkg/container/containersstate.go
+++ b/pkg/container/containersstate.go
@@ -81,3 +81,18 @@ func (s containersState) CreateAndStart(containerName string) error {
 
 	return nil
 }
+
+// Export converts unexported containersState to exported type, so it can be serialized and stored.
+func (s containersState) Export() ContainersState {
+	cs := ContainersState{}
+
+	for i, m := range s {
+		cs[i] = &HostConfiguredContainer{
+			Container:   m.container,
+			Host:        m.host,
+			ConfigFiles: m.configFiles,
+		}
+	}
+
+	return cs
+}

--- a/pkg/container/containersstate.go
+++ b/pkg/container/containersstate.go
@@ -65,6 +65,7 @@ func (s containersState) RemoveContainer(containerName string) error {
 	return nil
 }
 
+// CreateAndStart is a helper, which creates and spawns given container.
 func (s containersState) CreateAndStart(containerName string) error {
 	if _, exists := s[containerName]; !exists {
 		return fmt.Errorf("can't create non-existing container")

--- a/pkg/container/containersstate.go
+++ b/pkg/container/containersstate.go
@@ -91,6 +91,7 @@ func (s containersState) Export() ContainersState {
 			Container:   m.container,
 			Host:        m.host,
 			ConfigFiles: m.configFiles,
+			Hooks:       m.hooks,
 		}
 	}
 

--- a/pkg/container/containersstate_test.go
+++ b/pkg/container/containersstate_test.go
@@ -1,0 +1,34 @@
+package container
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/flexkube/libflexkube/pkg/container/types"
+)
+
+func TestToExported(t *testing.T) {
+	c := containersState{
+		"foo": &hostConfiguredContainer{
+			container: Container{
+				Config: types.ContainerConfig{
+					Name: "foo",
+				},
+			},
+		},
+	}
+
+	expected := ContainersState{
+		"foo": &HostConfiguredContainer{
+			Container: Container{
+				Config: types.ContainerConfig{
+					Name: "foo",
+				},
+			},
+		},
+	}
+
+	if r := c.Export(); !reflect.DeepEqual(r, expected) {
+		t.Fatalf("expected: %+v, got %+v", expected, r)
+	}
+}

--- a/pkg/container/hostconfiguredcontainer_integration_test.go
+++ b/pkg/container/hostconfiguredcontainer_integration_test.go
@@ -89,3 +89,56 @@ func TestHostConfiguredContainerDeployConfigFile(t *testing.T) {
 		t.Fatalf("Deleting host configured container status should succeed, got: %v", err)
 	}
 }
+
+func TestHostConfiguredContainerPostStartHook(t *testing.T) {
+	hookCalled := false
+
+	f := Hook(func() error {
+		hookCalled = true
+
+		return nil
+	})
+
+	h := &HostConfiguredContainer{
+		Host: host.Host{
+			DirectConfig: &direct.Config{},
+		},
+		Container: Container{
+			Runtime: RuntimeConfig{
+				Docker: &docker.Config{},
+			},
+			Config: types.ContainerConfig{
+				Name:  "foo",
+				Image: "busybox:latest",
+			},
+		},
+		Hooks: &Hooks{
+			PostStart: &f,
+		},
+	}
+
+	hcc, err := h.New()
+	if err != nil {
+		t.Fatalf("Initializing host configured container should succeed, got: %v", err)
+	}
+
+	if err = hcc.Create(); err != nil {
+		t.Fatalf("Creating host configured container should succeed, got: %v", err)
+	}
+
+	if err = hcc.Start(); err != nil {
+		t.Fatalf("Starting host configured container should succeed, got: %v", err)
+	}
+
+	if !hookCalled {
+		t.Errorf("PostStart hook should be called")
+	}
+
+	if err = hcc.Stop(); err != nil {
+		t.Errorf("Stopping host configured container status should succeed, got: %v", err)
+	}
+
+	if err = hcc.Delete(); err != nil {
+		t.Fatalf("Deleting host configured container status should succeed, got: %v", err)
+	}
+}

--- a/pkg/container/hostconfiguredcontainer_test.go
+++ b/pkg/container/hostconfiguredcontainer_test.go
@@ -1,0 +1,62 @@
+package container
+
+import (
+	"testing"
+)
+
+// withHook()
+func TestWithHook(t *testing.T) {
+	action := false
+
+	if err := withHook(nil, func() error {
+		action = true
+
+		return nil
+	}, nil); err != nil {
+		t.Fatalf("withHook should not return error, got: %v", err)
+	}
+
+	if !action {
+		t.Fatalf("withHook should execute action")
+	}
+}
+
+func TestWithPreHook(t *testing.T) {
+	pre := false
+
+	f := Hook(func() error {
+		pre = true
+
+		return nil
+	})
+
+	if err := withHook(&f, func() error {
+		return nil
+	}, nil); err != nil {
+		t.Fatalf("withHook should not return error, got: %v", err)
+	}
+
+	if !pre {
+		t.Fatalf("withHook should call pre-hook")
+	}
+}
+
+func TestWithPostHook(t *testing.T) {
+	post := false
+
+	f := Hook(func() error {
+		post = true
+
+		return nil
+	})
+
+	if err := withHook(nil, func() error {
+		return nil
+	}, &f); err != nil {
+		t.Fatalf("withHook should not return error, got: %v", err)
+	}
+
+	if !post {
+		t.Fatalf("withHook should call post-hook")
+	}
+}


### PR DESCRIPTION
This commit adds Hooks field to HostConfiguredContainer, which allows
calling custom functions between certain steps of managing the
containers. This allows to perform various actions, like gracefully
remove the container from the cluster before stopping, restarting
processes when config files changes etc.

Currently only post-start hook is implemented. Others will be added on
demand.

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>