### PR TITLE
pkg/controlplane: use helpers and improve validation

### DIFF
--- a/e2e/templates/controlplane_config.yaml.tmpl
+++ b/e2e/templates/controlplane_config.yaml.tmpl
@@ -1,8 +1,8 @@
-kubernetesCACertificate: |
-    ${indent(4, trimspace(kubernetes_ca_certificate))}
-
-frontProxyCACertificate: |
-    ${indent(4, trimspace(front_proxy_ca_certificate))}
+common:
+    kubernetesCACertificate: |
+        ${indent(8, trimspace(kubernetes_ca_certificate))}
+    frontProxyCACertificate: |
+        ${indent(8, trimspace(front_proxy_ca_certificate))}
 
 kubeAPIServer:
     apiServerCertificate: |
@@ -41,18 +41,20 @@ kubeControllerManager:
         ${indent(8, trimspace(kubernetes_ca_key))}
     serviceAccountPrivateKey: |
         ${indent(8, trimspace(service_account_private_key))}
-    clientCertificate: |
-        ${indent(8, trimspace(kube_controller_manager_cert))}
-    clientKey: |
-        ${indent(8, trimspace(kube_controller_manager_key))}
     rootCACertificate: |
         ${indent(8, trimspace(root_ca_certificate))}
+    kubeconfig:
+        clientCertificate: |
+            ${indent(12, trimspace(kube_controller_manager_cert))}
+        clientKey: |
+            ${indent(12, trimspace(kube_controller_manager_key))}
 
 kubeScheduler:
-    clientCertificate: |
-        ${indent(8, trimspace(kube_scheduler_cert))}
-    clientKey: |
-        ${indent(8, trimspace(kube_scheduler_key))}
+    kubeconfig:
+        clientCertificate: |
+            ${indent(12, trimspace(kube_scheduler_cert))}
+        clientKey: |
+            ${indent(12, trimspace(kube_scheduler_key))}
 
 apiServerAddress: ${api_server_address}
 apiServerPort: 6443

--- a/pkg/container/containers_test.go
+++ b/pkg/container/containers_test.go
@@ -1,0 +1,95 @@
+package container
+
+import (
+	"testing"
+
+	"github.com/flexkube/libflexkube/pkg/container/runtime/docker"
+	"github.com/flexkube/libflexkube/pkg/container/types"
+	"github.com/flexkube/libflexkube/pkg/host"
+	"github.com/flexkube/libflexkube/pkg/host/transport/direct"
+)
+
+// New()
+func TestContainersNew(t *testing.T) {
+	GetContainers(t)
+}
+
+func GetContainers(t *testing.T) *containers {
+	cc := &Containers{
+		DesiredState: ContainersState{
+			"foo": &HostConfiguredContainer{
+				Host: host.Host{
+					DirectConfig: &direct.Config{},
+				},
+				Container: Container{
+					Runtime: RuntimeConfig{
+						Docker: &docker.Config{},
+					},
+					Config: types.ContainerConfig{
+						Name:  "foo",
+						Image: "busybox:latest",
+					},
+				},
+			},
+		},
+	}
+
+	c, err := cc.New()
+	if err != nil {
+		t.Fatalf("Creating empty containers object should work, got: %v", err)
+	}
+
+	return c
+}
+
+// CheckCurrentState()
+func TestContainersCheckCurrentStateNew(t *testing.T) {
+	c := GetContainers(t)
+
+	if err := c.CheckCurrentState(); err != nil {
+		t.Fatalf("Checking current state for new Containers should work, got: %v", err)
+	}
+}
+
+// CurrentStateToYaml()
+func TestContainersCurrentStateToYAML(t *testing.T) {
+	c := GetContainers(t)
+
+	_, err := c.CurrentStateToYaml()
+	if err != nil {
+		t.Fatalf("Getting current state in YAML format should work, got: %v", err)
+	}
+}
+
+// ToExported()
+func TestContainersToExported(t *testing.T) {
+	c := GetContainers(t)
+
+	c.ToExported()
+}
+
+// FromYaml()
+func TestContainersFromYamlBad(t *testing.T) {
+	if _, err := FromYaml([]byte{}); err == nil {
+		t.Fatalf("Creating containers from empty YAML should fail")
+	}
+}
+
+func TestContainersFromYaml(t *testing.T) {
+	y := `
+desiredState:
+ foo:
+   host:
+     direct: {}
+   container:
+     runtime:
+       docker: {}
+     config:
+       name: foo
+       image: busybox
+`
+
+	if _, err := FromYaml([]byte(y)); err != nil {
+		t.Fatalf("Creating containers from valid YAML should work, got: %v", err)
+	}
+}

--- a/pkg/controlplane/controlplane.go
+++ b/pkg/controlplane/controlplane.go
@@ -3,172 +3,148 @@ package controlplane
 import (
 	"fmt"
 
-	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
 
+	"github.com/flexkube/libflexkube/internal/util"
 	"github.com/flexkube/libflexkube/pkg/container"
+	"github.com/flexkube/libflexkube/pkg/defaults"
 	"github.com/flexkube/libflexkube/pkg/host"
 	"github.com/flexkube/libflexkube/pkg/host/transport/direct"
 	"github.com/flexkube/libflexkube/pkg/host/transport/ssh"
+	"github.com/flexkube/libflexkube/pkg/kubernetes/client"
 	"github.com/flexkube/libflexkube/pkg/types"
 )
 
-// Controlplane represents etcd controlplane configuration and state from the user
+// Common struct contains fields, which are common between all controlplane components.
+type Common struct {
+	Image                   string            `json:"image" yaml:"image"`
+	KubernetesCACertificate types.Certificate `json:"kubernetesCACertificate" yaml:"kubernetesCACertificate"`
+	FrontProxyCACertificate types.Certificate `json:"frontProxyCACertificate" yaml:"frontProxyCACertificate"`
+}
+
+// GetImage returns either image defined in common config or Kubernetes default image.
+func (co Common) GetImage() string {
+	return util.PickString(co.Image, defaults.KubernetesImage)
+}
+
+// Controlplane represents kubernetes controlplane configuration and state from the user.
 type Controlplane struct {
 	// User-configurable fields
 	// They should be defined here if they are used more than once. Things like serviceCIDR, which is only needed in KubeAPIServer,
 	// should be defined directly there.
-	Image                   string                `json:"image,omitempty" yaml:"image,omitempty"`
-	SSH                     *ssh.Config           `json:"ssh,omitempty" yaml:"ssh,omitempty"`
-	KubernetesCACertificate types.Certificate     `json:"kubernetesCACertificate,omitempty" yaml:"kubernetesCACertificate,omitempty"`
-	FrontProxyCACertificate types.Certificate     `json:"frontProxyCACertificate,omitempty" yaml:"frontProxyCACertificate,omitempty"`
-	APIServerAddress        string                `json:"apiServerAddress,omitempty" yaml:"apiServerAddress,omitempty"`
-	APIServerPort           int                   `json:"apiServerPort,omitempty" yaml:"apiServerPort,omitempty"`
-	KubeAPIServer           KubeAPIServer         `json:"kubeAPIServer,omitempty" yaml:"kubeAPIServer,omitempty"`
-	KubeControllerManager   KubeControllerManager `json:"kubeControllerManager,omitempty" yaml:"kubeControllerManager,omitempty"`
-	KubeScheduler           KubeScheduler         `json:"kubeScheduler,omitempty" yaml:"kubeScheduler,omitempty"`
+	Common                Common                `json:"common" yaml:"common"`
+	SSH                   *ssh.Config           `json:"ssh" yaml:"ssh"`
+	APIServerAddress      string                `json:"apiServerAddress" yaml:"apiServerAddress"`
+	APIServerPort         int                   `json:"apiServerPort" yaml:"apiServerPort"`
+	KubeAPIServer         KubeAPIServer         `json:"kubeAPIServer" yaml:"kubeAPIServer"`
+	KubeControllerManager KubeControllerManager `json:"kubeControllerManager" yaml:"kubeControllerManager"`
+	KubeScheduler         KubeScheduler         `json:"kubeScheduler" yaml:"kubeScheduler"`
 
-	Shutdown bool `json:"shutdown,omitempty" yaml:"shutdown,omitempty"`
+	Shutdown bool `json:"shutdown" yaml:"shutdown"`
 
 	// Serializable fields
-	State container.ContainersState `json:"state:omitempty" yaml:"state,omitempty"`
+	State container.ContainersState `json:"state" yaml:"state"`
 }
 
-// controlplane is executable version of Controlplane, with validated fields and calculated containers
+// controlplane is executable version of Controlplane, with validated fields and calculated containers.
 type controlplane struct {
-	image                   string
-	ssh                     *ssh.Config
-	kubernetesCACertificate string
-	apiServerAddress        string
-	apiServerPort           int
-	shutdown                bool
+	common           Common
+	ssh              *ssh.Config
+	apiServerAddress string
+	apiServerPort    int
+	shutdown         bool
 
 	containers container.Containers
 }
 
-// buildKubeScheduler fills KubeSheduler struct with all default values
+// propagateKubeconfig merges given client config with values stored in Controlplane.
+// Values in given config has priority over ones from the Controlplane.
+func (c *Controlplane) propagateKubeconfig(d *client.Config) {
+	d.CACertificate = types.Certificate(util.PickString(string(d.CACertificate), string(c.Common.KubernetesCACertificate)))
+
+	if c.APIServerAddress != "" && c.APIServerPort != 0 {
+		d.Server = util.PickString(d.Server, fmt.Sprintf("%s:%d", c.APIServerAddress, c.APIServerPort))
+	}
+}
+
+// propagateHost merges given host configuration with values stored in Controlplane.
+// Values in given host config has priority over ones from the Controlplane.
+func (c *Controlplane) propagateHost(h host.Host) host.Host {
+	if h.DirectConfig == nil && h.SSHConfig == nil && c.SSH == nil {
+		return host.Host{
+			DirectConfig: &direct.Config{},
+		}
+	}
+
+	h.SSHConfig = ssh.BuildConfig(h.SSHConfig, c.SSH)
+
+	return h
+}
+
+// propagateCommon merges given common configuration with values stored in Controlplane.
+// Values in given common configuration has priority over ones from the Controlplane.
+func (c *Controlplane) propagateCommon(co *Common) {
+	co.Image = util.PickString(co.Image, c.Common.Image)
+	co.KubernetesCACertificate = types.Certificate(util.PickString(string(co.KubernetesCACertificate), string(c.Common.KubernetesCACertificate)))
+	co.FrontProxyCACertificate = types.Certificate(util.PickString(string(co.FrontProxyCACertificate), string(c.Common.FrontProxyCACertificate)))
+}
+
+// buildKubeScheduler fills KubeSheduler struct with all default values.
 func (c *Controlplane) buildKubeScheduler() {
-	if c.KubeScheduler.Image == "" && c.Image != "" {
-		c.KubeScheduler.Image = c.Image
-	}
+	k := &c.KubeScheduler
 
-	if c.KubeScheduler.KubernetesCACertificate == "" && c.KubernetesCACertificate != "" {
-		c.KubeScheduler.KubernetesCACertificate = string(c.KubernetesCACertificate)
-	}
+	c.propagateKubeconfig(&k.Kubeconfig)
 
-	if c.KubeScheduler.FrontProxyCACertificate == "" && c.FrontProxyCACertificate != "" {
-		c.KubeScheduler.FrontProxyCACertificate = string(c.FrontProxyCACertificate)
-	}
+	c.propagateCommon(&k.Common)
 
-	if c.KubeScheduler.APIServer == "" && c.APIServerAddress != "" {
-		c.KubeScheduler.APIServer = c.APIServerAddress
-	}
-
-	// TODO find better way to handle defaults!!!
-	if (c.KubeScheduler.Host == nil || (c.KubeScheduler.Host.DirectConfig == nil && c.KubeScheduler.Host.SSHConfig == nil)) && c.SSH == nil {
-		c.KubeScheduler.Host = &host.Host{
-			DirectConfig: &direct.Config{},
-		}
-	}
-
-	if c.KubeScheduler.Host == nil {
-		c.KubeScheduler.Host = &host.Host{
-			SSHConfig: c.SSH,
-		}
-	}
-
-	c.KubeScheduler.Host.SSHConfig = ssh.BuildConfig(c.KubeScheduler.Host.SSHConfig, c.SSH)
+	k.Host = c.propagateHost(k.Host)
 }
 
-// buildKubeControllerManager fills KubeControllerManager with all default values
+// buildKubeControllerManager fills KubeControllerManager with all default values.
 func (c *Controlplane) buildKubeControllerManager() {
-	if c.KubeControllerManager.Image == "" && c.Image != "" {
-		c.KubeControllerManager.Image = c.Image
-	}
+	k := &c.KubeControllerManager
 
-	if c.KubeControllerManager.KubernetesCACertificate == "" && c.KubernetesCACertificate != "" {
-		c.KubeControllerManager.KubernetesCACertificate = string(c.KubernetesCACertificate)
-	}
+	c.propagateKubeconfig(&k.Kubeconfig)
 
-	if c.KubeControllerManager.FrontProxyCACertificate == "" && c.FrontProxyCACertificate != "" {
-		c.KubeControllerManager.FrontProxyCACertificate = string(c.FrontProxyCACertificate)
-	}
+	c.propagateCommon(&k.Common)
 
-	if c.KubeControllerManager.APIServer == "" && c.APIServerAddress != "" {
-		c.KubeControllerManager.APIServer = c.APIServerAddress
-	}
-
-	// TODO find better way to handle defaults!!!
-	if (c.KubeControllerManager.Host == nil || (c.KubeControllerManager.Host.DirectConfig == nil && c.KubeControllerManager.Host.SSHConfig == nil)) && c.SSH == nil {
-		c.KubeControllerManager.Host = &host.Host{
-			DirectConfig: &direct.Config{},
-		}
-	}
-
-	if c.KubeControllerManager.Host == nil {
-		c.KubeControllerManager.Host = &host.Host{
-			SSHConfig: c.SSH,
-		}
-	}
-
-	c.KubeControllerManager.Host.SSHConfig = ssh.BuildConfig(c.KubeControllerManager.Host.SSHConfig, c.SSH)
+	k.Host = c.propagateHost(k.Host)
 }
 
-// buildKubeAPIServer fills KubeAPIServer with all default values
+// buildKubeAPIServer fills KubeAPIServer with all default values.
 func (c *Controlplane) buildKubeAPIServer() {
-	if c.KubeAPIServer.Image == "" && c.Image != "" {
-		c.KubeAPIServer.Image = c.Image
+	k := &c.KubeAPIServer
+
+	if k.BindAddress == "" && c.APIServerAddress != "" {
+		k.BindAddress = c.APIServerAddress
 	}
 
-	if c.KubeAPIServer.KubernetesCACertificate == "" && c.KubernetesCACertificate != "" {
-		c.KubeAPIServer.KubernetesCACertificate = c.KubernetesCACertificate
+	if k.AdvertiseAddress == "" && c.APIServerAddress != "" {
+		k.AdvertiseAddress = c.APIServerAddress
 	}
 
-	if c.KubeAPIServer.FrontProxyCACertificate == "" && c.FrontProxyCACertificate != "" {
-		c.KubeAPIServer.FrontProxyCACertificate = c.FrontProxyCACertificate
+	if k.SecurePort == 0 && c.APIServerPort != 0 {
+		k.SecurePort = c.APIServerPort
 	}
 
-	if c.KubeAPIServer.BindAddress == "" && c.APIServerAddress != "" {
-		c.KubeAPIServer.BindAddress = c.APIServerAddress
-	}
+	c.propagateCommon(&k.Common)
 
-	if c.KubeAPIServer.AdvertiseAddress == "" && c.APIServerAddress != "" {
-		c.KubeAPIServer.AdvertiseAddress = c.APIServerAddress
-	}
-
-	if c.KubeAPIServer.SecurePort == 0 && c.APIServerPort != 0 {
-		c.KubeAPIServer.SecurePort = c.APIServerPort
-	}
-
-	// TODO find better way to handle defaults!!!
-	if (c.KubeAPIServer.Host == nil || (c.KubeAPIServer.Host.DirectConfig == nil && c.KubeAPIServer.Host.SSHConfig == nil)) && c.SSH == nil {
-		c.KubeAPIServer.Host = &host.Host{
-			DirectConfig: &direct.Config{},
-		}
-	}
-
-	if c.KubeAPIServer.Host == nil {
-		c.KubeAPIServer.Host = &host.Host{
-			SSHConfig: c.SSH,
-		}
-	}
-
-	c.KubeAPIServer.Host.SSHConfig = ssh.BuildConfig(c.KubeAPIServer.Host.SSHConfig, c.SSH)
+	k.Host = c.propagateHost(k.Host)
 }
 
 // New validates Controlplane configuration and fills populates all values provided by the users
-// to the structs underneath
+// to the structs underneath.
 func (c *Controlplane) New() (*controlplane, error) {
 	if err := c.Validate(); err != nil {
 		return nil, fmt.Errorf("failed to validate controlplane configuration: %w", err)
 	}
 
 	controlplane := &controlplane{
-		image:                   c.Image,
-		ssh:                     c.SSH,
-		kubernetesCACertificate: string(c.KubernetesCACertificate),
-		apiServerAddress:        c.APIServerAddress,
-		apiServerPort:           c.APIServerPort,
-		shutdown:                c.Shutdown,
+		common:           c.Common,
+		ssh:              c.SSH,
+		apiServerAddress: c.APIServerAddress,
+		apiServerPort:    c.APIServerPort,
+		shutdown:         c.Shutdown,
 		containers: container.Containers{
 			PreviousState: c.State,
 			DesiredState:  make(container.ContainersState),
@@ -180,43 +156,49 @@ func (c *Controlplane) New() (*controlplane, error) {
 		return controlplane, nil
 	}
 
-	c.buildKubeAPIServer()
+	// Make sure all values are filled.
+	c.buildComponents()
 
-	kas, err := c.KubeAPIServer.New()
-	if err != nil {
-		return nil, fmt.Errorf("that was unexpected: %w", err)
+	// Skip error checking, as it's done in Verify().
+	kas, _ := c.KubeAPIServer.New()
+
+	kcm, _ := c.KubeControllerManager.New()
+
+	ks, _ := c.KubeScheduler.New()
+
+	controlplane.containers.DesiredState = container.ContainersState{
+		"kube-apiserver":          kas.ToHostConfiguredContainer(),
+		"kube-controller-manager": kcm.ToHostConfiguredContainer(),
+		"kube-scheduler":          ks.ToHostConfiguredContainer(),
 	}
-
-	controlplane.containers.DesiredState["kube-apiserver"] = kas.ToHostConfiguredContainer()
-
-	c.buildKubeControllerManager()
-
-	kcm, err := c.KubeControllerManager.New()
-	if err != nil {
-		return nil, fmt.Errorf("that was unexpected: %w", err)
-	}
-
-	controlplane.containers.DesiredState["kube-controller-manager"] = kcm.ToHostConfiguredContainer()
-
-	c.buildKubeScheduler()
-
-	ks, err := c.KubeScheduler.New()
-	if err != nil {
-		return nil, fmt.Errorf("that was unexpected: %w", err)
-	}
-
-	controlplane.containers.DesiredState["kube-scheduler"] = ks.ToHostConfiguredContainer()
 
 	return controlplane, nil
 }
 
-// Validate validates Controlplane configuration
+// buildComponents fills controlplane component structs with default values inherited
+// from controlplane struct.
+func (c *Controlplane) buildComponents() {
+	c.buildKubeAPIServer()
+	c.buildKubeControllerManager()
+	c.buildKubeScheduler()
+}
+
+// Validate validates Controlplane configuration.
 func (c *Controlplane) Validate() error {
-	if c.FrontProxyCACertificate == "" {
-		return fmt.Errorf("field frontProxyCACertificate is empty")
+	c.buildComponents()
+
+	if _, err := c.KubeAPIServer.New(); err != nil {
+		return fmt.Errorf("failed to verify kube-apiserver configuration: %w", err)
 	}
 
-	// TODO too many things to validate, let's skip it for now
+	if _, err := c.KubeControllerManager.New(); err != nil {
+		return fmt.Errorf("failed to verify kube-controller-manager: %w", err)
+	}
+
+	if _, err := c.KubeScheduler.New(); err != nil {
+		return fmt.Errorf("failed to verify kube-scheduler configuration: %w", err)
+	}
+
 	return nil
 }
 

--- a/pkg/controlplane/kube-apiserver.go
+++ b/pkg/controlplane/kube-apiserver.go
@@ -173,22 +173,24 @@ func (k *KubeAPIServer) New() (*kubeAPIServer, error) {
 //
 // TODO add validation of certificates if specified
 func (k *KubeAPIServer) Validate() error {
+	var errors types.ValidateError
+
 	b, err := yaml.Marshal(k)
 	if err != nil {
-		return fmt.Errorf("failed to validate: %w", err)
+		return append(errors, fmt.Errorf("failed to validate: %w", err))
 	}
 
 	if err := yaml.Unmarshal(b, &k); err != nil {
-		return fmt.Errorf("validation failed: %w", err)
+		return append(errors, fmt.Errorf("validation failed: %w", err))
 	}
 
 	if len(k.EtcdServers) == 0 {
-		return fmt.Errorf("at least one etcd server must be defined")
+		errors = append(errors, fmt.Errorf("at least one etcd server must be defined"))
 	}
 
 	if err := k.Host.Validate(); err != nil {
-		return fmt.Errorf("host config validation failed: %w", err)
+		errors = append(errors, fmt.Errorf("host config validation failed: %w", err))
 	}
 
-	return nil
+	return errors.Return()
 }

--- a/pkg/controlplane/kube-apiserver_test.go
+++ b/pkg/controlplane/kube-apiserver_test.go
@@ -12,6 +12,9 @@ import (
 const (
 	// securePort is a TLS port used for testing.
 	securePort = 6443
+
+	// nonEmptyString is a string used for testing.
+	nonEmptyString = "foo"
 )
 
 func TestKubeAPIServerToHostConfiguredContainer(t *testing.T) {
@@ -19,7 +22,10 @@ func TestKubeAPIServerToHostConfiguredContainer(t *testing.T) {
 	privateKey := types.PrivateKey(utiltest.GenerateRSAPrivateKey(t))
 
 	kas := &KubeAPIServer{
-		KubernetesCACertificate:  cert,
+		Common: Common{
+			KubernetesCACertificate: cert,
+			FrontProxyCACertificate: cert,
+		},
 		APIServerCertificate:     cert,
 		APIServerKey:             privateKey,
 		ServiceAccountPublicKey:  nonEmptyString,
@@ -28,7 +34,6 @@ func TestKubeAPIServerToHostConfiguredContainer(t *testing.T) {
 		EtcdServers:              []string{nonEmptyString},
 		ServiceCIDR:              nonEmptyString,
 		SecurePort:               securePort,
-		FrontProxyCACertificate:  cert,
 		FrontProxyCertificate:    cert,
 		FrontProxyKey:            privateKey,
 		KubeletClientCertificate: cert,
@@ -36,7 +41,7 @@ func TestKubeAPIServerToHostConfiguredContainer(t *testing.T) {
 		EtcdCACertificate:        cert,
 		EtcdClientCertificate:    cert,
 		EtcdClientKey:            privateKey,
-		Host: &host.Host{
+		Host: host.Host{
 			DirectConfig: &direct.Config{},
 		},
 	}
@@ -54,8 +59,13 @@ func TestKubeAPIServerValidate(t *testing.T) {
 	cert := types.Certificate(utiltest.GenerateX509Certificate(t))
 	privateKey := types.PrivateKey(utiltest.GenerateRSAPrivateKey(t))
 
-	hostConfig := &host.Host{
+	hostConfig := host.Host{
 		DirectConfig: &direct.Config{},
+	}
+
+	common := Common{
+		KubernetesCACertificate: cert,
+		FrontProxyCACertificate: cert,
 	}
 
 	cases := map[string]struct {
@@ -64,7 +74,7 @@ func TestKubeAPIServerValidate(t *testing.T) {
 	}{
 		"require kubeletClientCertificate": {
 			Config: &KubeAPIServer{
-				KubernetesCACertificate: cert,
+				Common:                  common,
 				APIServerCertificate:    cert,
 				APIServerKey:            privateKey,
 				ServiceAccountPublicKey: nonEmptyString,
@@ -73,7 +83,6 @@ func TestKubeAPIServerValidate(t *testing.T) {
 				EtcdServers:             []string{nonEmptyString},
 				ServiceCIDR:             nonEmptyString,
 				SecurePort:              securePort,
-				FrontProxyCACertificate: cert,
 				FrontProxyCertificate:   cert,
 				FrontProxyKey:           privateKey,
 				KubeletClientKey:        privateKey,
@@ -86,7 +95,7 @@ func TestKubeAPIServerValidate(t *testing.T) {
 		},
 		"validate kubeletClientCertificate": {
 			Config: &KubeAPIServer{
-				KubernetesCACertificate:  cert,
+				Common:                   common,
 				APIServerCertificate:     cert,
 				APIServerKey:             privateKey,
 				ServiceAccountPublicKey:  nonEmptyString,
@@ -95,7 +104,6 @@ func TestKubeAPIServerValidate(t *testing.T) {
 				EtcdServers:              []string{nonEmptyString},
 				ServiceCIDR:              nonEmptyString,
 				SecurePort:               securePort,
-				FrontProxyCACertificate:  cert,
 				FrontProxyCertificate:    cert,
 				FrontProxyKey:            privateKey,
 				KubeletClientKey:         privateKey,
@@ -109,7 +117,7 @@ func TestKubeAPIServerValidate(t *testing.T) {
 		},
 		"valid": {
 			Config: &KubeAPIServer{
-				KubernetesCACertificate:  cert,
+				Common:                   common,
 				APIServerCertificate:     cert,
 				APIServerKey:             privateKey,
 				ServiceAccountPublicKey:  nonEmptyString,
@@ -118,7 +126,6 @@ func TestKubeAPIServerValidate(t *testing.T) {
 				EtcdServers:              []string{nonEmptyString},
 				ServiceCIDR:              nonEmptyString,
 				SecurePort:               securePort,
-				FrontProxyCACertificate:  cert,
 				FrontProxyCertificate:    cert,
 				FrontProxyKey:            privateKey,
 				KubeletClientKey:         privateKey,

--- a/pkg/controlplane/kube-controller-manager_test.go
+++ b/pkg/controlplane/kube-controller-manager_test.go
@@ -3,142 +3,93 @@ package controlplane
 import (
 	"testing"
 
+	"github.com/flexkube/libflexkube/internal/utiltest"
 	"github.com/flexkube/libflexkube/pkg/host"
 	"github.com/flexkube/libflexkube/pkg/host/transport/direct"
-)
-
-const (
-	nonEmptyString = "foo"
+	"github.com/flexkube/libflexkube/pkg/kubernetes/client"
+	"github.com/flexkube/libflexkube/pkg/types"
 )
 
 func TestKubeControllerManagerValidate(t *testing.T) {
-	hostConfig := &host.Host{
+	hostConfig := host.Host{
 		DirectConfig: &direct.Config{},
+	}
+
+	pki := utiltest.GeneratePKI(t)
+
+	kubeconfig := client.Config{
+		Server:            "localhost",
+		CACertificate:     types.Certificate(pki.Certificate),
+		ClientCertificate: types.Certificate(pki.Certificate),
+		ClientKey:         types.PrivateKey(pki.PrivateKey),
 	}
 
 	cases := map[string]struct {
 		Config *KubeControllerManager
 		Error  bool
 	}{
-		"require KubernetesCACertificate": {
+		"require Kubeconfig": {
 			Config: &KubeControllerManager{
-				KubernetesCAKey:          nonEmptyString,
-				ServiceAccountPrivateKey: nonEmptyString,
-				APIServer:                nonEmptyString,
-				ClientCertificate:        nonEmptyString,
-				ClientKey:                nonEmptyString,
-				RootCACertificate:        nonEmptyString,
+				KubernetesCAKey:          types.PrivateKey(pki.PrivateKey),
+				ServiceAccountPrivateKey: types.PrivateKey(pki.PrivateKey),
+				RootCACertificate:        types.Certificate(pki.Certificate),
 				Host:                     hostConfig,
 			},
 			Error: true,
 		},
 		"require KubernetesCAKey": {
 			Config: &KubeControllerManager{
-				KubernetesCACertificate:  nonEmptyString,
-				ServiceAccountPrivateKey: nonEmptyString,
-				APIServer:                nonEmptyString,
-				ClientCertificate:        nonEmptyString,
-				ClientKey:                nonEmptyString,
-				RootCACertificate:        nonEmptyString,
+				ServiceAccountPrivateKey: types.PrivateKey(pki.PrivateKey),
+				RootCACertificate:        types.Certificate(pki.Certificate),
 				Host:                     hostConfig,
+				Kubeconfig:               kubeconfig,
 			},
 			Error: true,
 		},
 		"require ServiceAccountPrivateKey": {
 			Config: &KubeControllerManager{
-				KubernetesCACertificate: nonEmptyString,
-				KubernetesCAKey:         nonEmptyString,
-				APIServer:               nonEmptyString,
-				ClientCertificate:       nonEmptyString,
-				ClientKey:               nonEmptyString,
-				RootCACertificate:       nonEmptyString,
-				Host:                    hostConfig,
-			},
-			Error: true,
-		},
-		"require APIServer": {
-			Config: &KubeControllerManager{
-				KubernetesCACertificate:  nonEmptyString,
-				KubernetesCAKey:          nonEmptyString,
-				ServiceAccountPrivateKey: nonEmptyString,
-				ClientCertificate:        nonEmptyString,
-				ClientKey:                nonEmptyString,
-				RootCACertificate:        nonEmptyString,
-				Host:                     hostConfig,
-			},
-			Error: true,
-		},
-		"require ClientCertificate": {
-			Config: &KubeControllerManager{
-				KubernetesCACertificate:  nonEmptyString,
-				KubernetesCAKey:          nonEmptyString,
-				ServiceAccountPrivateKey: nonEmptyString,
-				APIServer:                nonEmptyString,
-				ClientKey:                nonEmptyString,
-				RootCACertificate:        nonEmptyString,
-				Host:                     hostConfig,
-			},
-			Error: true,
-		},
-		"require ClientKey": {
-			Config: &KubeControllerManager{
-				KubernetesCACertificate:  nonEmptyString,
-				KubernetesCAKey:          nonEmptyString,
-				ServiceAccountPrivateKey: nonEmptyString,
-				APIServer:                nonEmptyString,
-				ClientCertificate:        nonEmptyString,
-				RootCACertificate:        nonEmptyString,
-				Host:                     hostConfig,
+				KubernetesCAKey:   types.PrivateKey(pki.PrivateKey),
+				RootCACertificate: types.Certificate(pki.Certificate),
+				Host:              hostConfig,
+				Kubeconfig:        kubeconfig,
 			},
 			Error: true,
 		},
 		"require RootCACertificate": {
 			Config: &KubeControllerManager{
-				KubernetesCACertificate:  nonEmptyString,
-				KubernetesCAKey:          nonEmptyString,
-				ServiceAccountPrivateKey: nonEmptyString,
-				APIServer:                nonEmptyString,
-				ClientCertificate:        nonEmptyString,
-				ClientKey:                nonEmptyString,
+				KubernetesCAKey:          types.PrivateKey(pki.PrivateKey),
+				ServiceAccountPrivateKey: types.PrivateKey(pki.PrivateKey),
 				Host:                     hostConfig,
+				Kubeconfig:               kubeconfig,
 			},
 			Error: true,
 		},
 		"no host": {
 			Config: &KubeControllerManager{
-				KubernetesCACertificate:  nonEmptyString,
-				KubernetesCAKey:          nonEmptyString,
-				ServiceAccountPrivateKey: nonEmptyString,
-				APIServer:                nonEmptyString,
-				ClientCertificate:        nonEmptyString,
-				ClientKey:                nonEmptyString,
-				RootCACertificate:        nonEmptyString,
+				KubernetesCAKey:          types.PrivateKey(pki.PrivateKey),
+				ServiceAccountPrivateKey: types.PrivateKey(pki.PrivateKey),
+				RootCACertificate:        types.Certificate(pki.Certificate),
+				Kubeconfig:               kubeconfig,
 			},
 			Error: true,
 		},
 		"bad host": {
 			Config: &KubeControllerManager{
-				KubernetesCACertificate:  nonEmptyString,
-				KubernetesCAKey:          nonEmptyString,
-				ServiceAccountPrivateKey: nonEmptyString,
-				APIServer:                nonEmptyString,
-				ClientCertificate:        nonEmptyString,
-				ClientKey:                nonEmptyString,
-				RootCACertificate:        nonEmptyString,
-				Host:                     &host.Host{},
+				KubernetesCAKey:          types.PrivateKey(pki.PrivateKey),
+				ServiceAccountPrivateKey: types.PrivateKey(pki.PrivateKey),
+				RootCACertificate:        types.Certificate(pki.Certificate),
+				Kubeconfig:               kubeconfig,
+				Host:                     host.Host{},
 			},
 			Error: true,
 		},
 		"valid": {
 			Config: &KubeControllerManager{
-				KubernetesCACertificate:  nonEmptyString,
-				KubernetesCAKey:          nonEmptyString,
-				ServiceAccountPrivateKey: nonEmptyString,
-				APIServer:                nonEmptyString,
-				ClientCertificate:        nonEmptyString,
-				ClientKey:                nonEmptyString,
-				RootCACertificate:        nonEmptyString,
+				KubernetesCAKey:          types.PrivateKey(pki.PrivateKey),
+				ServiceAccountPrivateKey: types.PrivateKey(pki.PrivateKey),
+				RootCACertificate:        types.Certificate(pki.Certificate),
 				Host:                     hostConfig,
+				Kubeconfig:               kubeconfig,
 			},
 			Error: false,
 		},
@@ -155,41 +106,21 @@ func TestKubeControllerManagerValidate(t *testing.T) {
 	}
 }
 
-func TestKubeControllerManagerNewFillImage(t *testing.T) {
+func TestKubeControllerManagerToHostConfiguredContainer(t *testing.T) {
+	pki := utiltest.GeneratePKI(t)
+
 	kcm := &KubeControllerManager{
-		KubernetesCACertificate:  nonEmptyString,
-		KubernetesCAKey:          nonEmptyString,
-		ServiceAccountPrivateKey: nonEmptyString,
-		APIServer:                nonEmptyString,
-		ClientCertificate:        nonEmptyString,
-		ClientKey:                nonEmptyString,
-		RootCACertificate:        nonEmptyString,
-		Host: &host.Host{
+		KubernetesCAKey:          types.PrivateKey(pki.PrivateKey),
+		ServiceAccountPrivateKey: types.PrivateKey(pki.PrivateKey),
+		RootCACertificate:        types.Certificate(pki.Certificate),
+		Host: host.Host{
 			DirectConfig: &direct.Config{},
 		},
-	}
-
-	o, err := kcm.New()
-	if err != nil {
-		t.Fatalf("new should not return error, got: %v", err)
-	}
-
-	if o.image == "" {
-		t.Fatalf("New() should set default image if it's not present")
-	}
-}
-
-func TestKubeControllerManagerToHostConfiguredContainer(t *testing.T) {
-	kcm := &KubeControllerManager{
-		KubernetesCACertificate:  nonEmptyString,
-		KubernetesCAKey:          nonEmptyString,
-		ServiceAccountPrivateKey: nonEmptyString,
-		APIServer:                nonEmptyString,
-		ClientCertificate:        nonEmptyString,
-		ClientKey:                nonEmptyString,
-		RootCACertificate:        nonEmptyString,
-		Host: &host.Host{
-			DirectConfig: &direct.Config{},
+		Kubeconfig: client.Config{
+			Server:            "localhost",
+			CACertificate:     types.Certificate(pki.Certificate),
+			ClientCertificate: types.Certificate(pki.Certificate),
+			ClientKey:         types.PrivateKey(pki.PrivateKey),
 		},
 	}
 
@@ -199,5 +130,9 @@ func TestKubeControllerManagerToHostConfiguredContainer(t *testing.T) {
 	}
 
 	// TODO grab an object and perform some validation on it?
-	o.ToHostConfiguredContainer()
+	hcc := o.ToHostConfiguredContainer()
+
+	if hcc.Container.Config.Image == "" {
+		t.Fatalf("New() should set default image if it's not present")
+	}
 }

--- a/pkg/controlplane/kube-scheduler.go
+++ b/pkg/controlplane/kube-scheduler.go
@@ -1,49 +1,36 @@
 package controlplane
 
 import (
-	"encoding/base64"
 	"fmt"
 
 	"github.com/flexkube/libflexkube/pkg/container"
 	"github.com/flexkube/libflexkube/pkg/container/runtime/docker"
-	"github.com/flexkube/libflexkube/pkg/container/types"
-	"github.com/flexkube/libflexkube/pkg/defaults"
+	containertypes "github.com/flexkube/libflexkube/pkg/container/types"
 	"github.com/flexkube/libflexkube/pkg/host"
+	"github.com/flexkube/libflexkube/pkg/kubernetes/client"
 )
 
 // KubeScheduler represents kube-scheduler configuration data
 type KubeScheduler struct {
-	Image                   string     `json:"image,omitempty" yaml:"image,omitempty"`
-	Host                    *host.Host `json:"host,omitempty" yaml:"host,omitempty"`
-	KubernetesCACertificate string     `json:"kubernetesCACertificate,omitempty" yaml:"kubernetesCACertificate,omitempty"`
-	APIServer               string     `json:"apiServer,omitempty" yaml:"apiServer,omitempty"`
-	// TODO don't take the admin key, use dedicated certificate for static controller manager,
-	// which will have a group + create a binding to system:kube-controller-manager clusterRole
-	// as done in self-hosted chart.
-	// TODO since we have access to CA cert and key, we could generate certificate ourselves here
-	ClientCertificate       string `json:"clientCertificate,omitempty" yaml:"clientCertificate,omitempty"`
-	ClientKey               string `json:"clientKey,omitempty" yaml:"clientKey,omitempty"`
-	FrontProxyCACertificate string `json:"frontProxyCACertificate,omitempty" yaml:"frontProxyCACertificate,omitempty"`
+	Common     Common        `json:"common" yaml:"common"`
+	Host       host.Host     `json:"host" yaml:"host"`
+	Kubeconfig client.Config `json:"kubeconfig" yaml:"kubeconfig"`
 }
 
 // kubeScheduler is validated and usable version of KubeScheduler
 type kubeScheduler struct {
-	image                   string
-	host                    host.Host
-	kubernetesCACertificate string
-	apiServer               string
-	clientCertificate       string
-	clientKey               string
-	frontProxyCACertificate string
+	common     Common
+	host       host.Host
+	kubeconfig string
 }
 
 // ToHostConfiguredContainer converts kubeScheduler into generic container struct
 func (k *kubeScheduler) ToHostConfiguredContainer() *container.HostConfiguredContainer {
 	configFiles := make(map[string]string)
 	// TODO put all those path in a single place. Perhaps make them configurable with defaults too
-	configFiles["/etc/kubernetes/kube-scheduler/kubeconfig"] = k.toKubeconfig()
-	configFiles["/etc/kubernetes/kube-scheduler/pki/ca.crt"] = k.kubernetesCACertificate
-	configFiles["/etc/kubernetes/kube-scheduler/pki/front-proxy-ca.crt"] = k.frontProxyCACertificate
+	configFiles["/etc/kubernetes/kube-scheduler/kubeconfig"] = k.kubeconfig
+	configFiles["/etc/kubernetes/kube-scheduler/pki/ca.crt"] = string(k.common.KubernetesCACertificate)
+	configFiles["/etc/kubernetes/kube-scheduler/pki/front-proxy-ca.crt"] = string(k.common.FrontProxyCACertificate)
 	configFiles["/etc/kubernetes/kube-scheduler/kube-scheduler.yaml"] = `apiVersion: kubescheduler.config.k8s.io/v1alpha1
 kind: KubeSchedulerConfiguration
 clientConnection:
@@ -55,10 +42,10 @@ clientConnection:
 		Runtime: container.RuntimeConfig{
 			Docker: &docker.Config{},
 		},
-		Config: types.ContainerConfig{
+		Config: containertypes.ContainerConfig{
 			Name:  "kube-scheduler",
-			Image: k.image,
-			Mounts: []types.Mount{
+			Image: k.common.GetImage(),
+			Mounts: []containertypes.Mount{
 				{
 					Source: "/etc/kubernetes/kube-scheduler/",
 					Target: "/etc/kubernetes",
@@ -94,73 +81,25 @@ func (k *KubeScheduler) New() (*kubeScheduler, error) {
 		return nil, fmt.Errorf("failed to validate Kubernetes Scheduler configuration: %w", err)
 	}
 
-	nk := &kubeScheduler{
-		image:                   k.Image,
-		host:                    *k.Host,
-		kubernetesCACertificate: k.KubernetesCACertificate,
-		apiServer:               k.APIServer,
-		clientCertificate:       k.ClientCertificate,
-		clientKey:               k.ClientKey,
-		frontProxyCACertificate: k.FrontProxyCACertificate,
-	}
+	// It's fine to skip the error, Validate() will handle it.
+	kubeconfig, _ := k.Kubeconfig.ToYAMLString()
 
-	// The only optional parameter
-	if nk.image == "" {
-		nk.image = defaults.KubernetesImage
-	}
-
-	return nk, nil
+	return &kubeScheduler{
+		common:     k.Common,
+		host:       k.Host,
+		kubeconfig: kubeconfig,
+	}, nil
 }
 
-// Validate valides kube-scheduler configuration
-//
-// TODO add validation of certificates if specified
+// Validate valides kube-scheduler configuration.
 func (k *KubeScheduler) Validate() error {
-	if k.KubernetesCACertificate == "" {
-		return fmt.Errorf("field kubernetesCACertificate is empty")
+	if _, err := k.Kubeconfig.ToYAMLString(); err != nil {
+		return fmt.Errorf("invalid kubeconfig: %w", err)
 	}
 
-	if k.APIServer == "" {
-		return fmt.Errorf("field apiServer is empty")
-	}
-
-	if k.ClientCertificate == "" {
-		return fmt.Errorf("field clientCertificate is empty")
-	}
-
-	if k.ClientKey == "" {
-		return fmt.Errorf("field clientKey is empty")
-	}
-
-	if k.FrontProxyCACertificate == "" {
-		return fmt.Errorf("field frontProxyCACertificate is empty")
+	if err := k.Host.Validate(); err != nil {
+		return fmt.Errorf("host config validation failed: %w", err)
 	}
 
 	return nil
-}
-
-// toKubeconfig takes given configuration and returns kubeconfig file content for
-// kube-scheduler in YAML format
-//
-// TODO this is quite generic, refactor it
-func (k *kubeScheduler) toKubeconfig() string {
-	return fmt.Sprintf(`apiVersion: v1
-kind: Config
-clusters:
-- name: static
-  cluster:
-    server: https://%s:6443
-    certificate-authority-data: %s
-users:
-- name: static
-  user:
-    client-certificate-data: %s
-    client-key-data: %s
-current-context: static
-contexts:
-- name: static
-  context:
-    cluster: static
-    user: static
-`, k.apiServer, base64.StdEncoding.EncodeToString([]byte(k.kubernetesCACertificate)), base64.StdEncoding.EncodeToString([]byte(k.clientCertificate)), base64.StdEncoding.EncodeToString([]byte(k.clientKey)))
 }

--- a/pkg/host/transport/ssh/defaults.go
+++ b/pkg/host/transport/ssh/defaults.go
@@ -44,5 +44,7 @@ func BuildConfig(sshConfig *Config, defaults *Config) *Config {
 
 	sshConfig.Port = util.PickInt(sshConfig.Port, defaults.Port, Port)
 
+	sshConfig.Address = util.PickString(sshConfig.Address, defaults.Address)
+
 	return sshConfig
 }

--- a/pkg/host/transport/ssh/defaults_test.go
+++ b/pkg/host/transport/ssh/defaults_test.go
@@ -1,6 +1,7 @@
 package ssh
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -289,11 +290,61 @@ func TestBuildConfig(t *testing.T) {
 				RetryInterval:     "5s",
 			},
 		},
+
+		// Address
+		{
+			&Config{
+				Address: "localhost",
+			},
+			nil,
+			&Config{
+				ConnectionTimeout: ConnectionTimeout,
+				Port:              Port,
+				User:              User,
+				RetryTimeout:      RetryTimeout,
+				RetryInterval:     RetryInterval,
+				Address:           "localhost",
+			},
+		},
+		{
+			&Config{
+				Address: "localhost",
+			},
+			&Config{
+				Address: "foo",
+			},
+			&Config{
+				ConnectionTimeout: ConnectionTimeout,
+				Port:              Port,
+				User:              User,
+				RetryTimeout:      RetryTimeout,
+				RetryInterval:     RetryInterval,
+				Address:           "localhost",
+			},
+		},
+		{
+			nil,
+			&Config{
+				Address: "localhost",
+			},
+			&Config{
+				ConnectionTimeout: ConnectionTimeout,
+				Port:              Port,
+				User:              User,
+				RetryTimeout:      RetryTimeout,
+				RetryInterval:     RetryInterval,
+				Address:           "localhost",
+			},
+		},
 	}
 
-	for _, c := range cases {
-		if nc := BuildConfig(c.config, c.defaults); !reflect.DeepEqual(nc, c.result) {
-			t.Fatalf("expected %+v, got %+v", c.result, nc)
-		}
+	for i, c := range cases {
+		c := c
+
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			if nc := BuildConfig(c.config, c.defaults); !reflect.DeepEqual(nc, c.result) {
+				t.Fatalf("expected %+v, got %+v", c.result, nc)
+			}
+		})
 	}
 }

--- a/pkg/kubernetes/client/client_test.go
+++ b/pkg/kubernetes/client/client_test.go
@@ -1,0 +1,54 @@
+package client
+
+import (
+	"testing"
+)
+
+func TestCheckNodeExistsFakeKubeconfig(t *testing.T) {
+	kubeconfig := GetKubeconfig(t)
+
+	c, err := NewClient([]byte(kubeconfig))
+	if err != nil {
+		t.Fatalf("Failed creating client: %v", err)
+	}
+
+	e, err := c.CheckNodeExists("foo")()
+
+	if e == true {
+		t.Errorf("Node should never exists with fake kubeconfig")
+	}
+
+	if err == nil {
+		t.Errorf("Checking node existence should always fail with fake kubeconfig")
+	}
+}
+
+func TestWaitForNodeFakeKubeconfig(t *testing.T) {
+	kubeconfig := GetKubeconfig(t)
+
+	c, err := NewClient([]byte(kubeconfig))
+	if err != nil {
+		t.Fatalf("Failed creating client: %v", err)
+	}
+
+	if err := c.WaitForNode("foo"); err == nil {
+		t.Errorf("Waiting for node should always fail with fake kubeconfig")
+	}
+}
+
+func TestLabelNodeFakeKubeconfig(t *testing.T) {
+	kubeconfig := GetKubeconfig(t)
+
+	c, err := NewClient([]byte(kubeconfig))
+	if err != nil {
+		t.Fatalf("Failed creating client: %v", err)
+	}
+
+	l := map[string]string{
+		"foo": "bar",
+	}
+
+	if err := c.LabelNode("foo", l); err == nil {
+		t.Errorf("Labeling node should always fail with fake kubeconfig")
+	}
+}

--- a/pkg/kubernetes/client/getter_test.go
+++ b/pkg/kubernetes/client/getter_test.go
@@ -19,4 +19,8 @@ func TestGetter(t *testing.T) {
 	if _, err := g.ToRESTMapper(); err != nil {
 		t.Errorf("Turning getter into REST mapper should work, got: %v", err)
 	}
+
+	if c := g.ToRawKubeConfigLoader(); c == nil {
+		t.Errorf("Turning getter into RawKubeConfigLoader should work")
+	}
 }

--- a/pkg/kubernetes/client/kubeconfig.go
+++ b/pkg/kubernetes/client/kubeconfig.go
@@ -21,32 +21,34 @@ type Config struct {
 
 // Validate validates Config struct.
 func (c *Config) Validate() error {
+	var errors types.ValidateError
+
 	if c.Server == "" {
-		return fmt.Errorf("server is empty")
+		errors = append(errors, fmt.Errorf("server is empty"))
 	}
 
 	if c.ClientCertificate == "" {
-		return fmt.Errorf("client certificate is empty")
+		errors = append(errors, fmt.Errorf("client certificate is empty"))
 	}
 
 	if c.ClientKey == "" {
-		return fmt.Errorf("client key is empty")
+		errors = append(errors, fmt.Errorf("client key is empty"))
 	}
 
 	if c.CACertificate == "" {
-		return fmt.Errorf("ca certificate is empty")
+		errors = append(errors, fmt.Errorf("ca certificate is empty"))
 	}
 
 	b, err := yaml.Marshal(c)
 	if err != nil {
-		return fmt.Errorf("marshaling config should succeed, got: %w", err)
+		return append(errors, fmt.Errorf("marshaling config should succeed, got: %w", err))
 	}
 
 	if err := yaml.Unmarshal(b, c); err != nil {
-		return fmt.Errorf("certificate validation failed: %w", err)
+		return append(errors, fmt.Errorf("certificate validation failed: %w", err))
 	}
 
-	return nil
+	return errors.Return()
 }
 
 // ToYAMLString converts given configuration to kubeconfig format as YAML text

--- a/pkg/kubernetes/client/kubeconfig.go
+++ b/pkg/kubernetes/client/kubeconfig.go
@@ -11,7 +11,7 @@ import (
 	"github.com/flexkube/libflexkube/pkg/types"
 )
 
-// Config is a simlified version of kubeconfig.
+// Config is a simplified version of kubeconfig.
 type Config struct {
 	Server            string            `json:"server" yaml:"server"`
 	CACertificate     types.Certificate `json:"caCertificate" yaml:"caCertificate"`

--- a/pkg/kubernetes/client/kubeconfig_test.go
+++ b/pkg/kubernetes/client/kubeconfig_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/flexkube/libflexkube/internal/util"
 	"github.com/flexkube/libflexkube/internal/utiltest"
+	"github.com/flexkube/libflexkube/pkg/types"
 )
 
 // GetKubeconfig returns content of fake kubeconfig file for testing.
@@ -44,8 +45,181 @@ clientKey: |
 }
 
 // ToYAMLString()
-func TestToYAMLString(t *testing.T) {
+func TestUnmarshal(t *testing.T) {
 	if kubeconfig := GetKubeconfig(t); kubeconfig == "" {
 		t.Fatalf("Generated kubeconfig shouldn't be empty")
+	}
+}
+
+func TestToYAMLStringNew(t *testing.T) {
+	cases := []struct {
+		f   func(*Config)
+		err func(error, *testing.T)
+	}{
+		{
+			func(c *Config) {
+				c.CACertificate = "ddd"
+			},
+			func(err error, t *testing.T) {
+				if err == nil {
+					t.Errorf("Kubeconfig with bad CA Certificate should be invalid")
+				}
+			},
+		},
+		{
+			func(c *Config) {
+				c.ClientCertificate = "foo"
+			},
+			func(err error, t *testing.T) {
+				if err == nil {
+					t.Errorf("Kubeconfig with bad client certificate should be invalid")
+				}
+			},
+		},
+		{
+			func(c *Config) {
+				c.ClientKey = "foo"
+			},
+			func(err error, t *testing.T) {
+				if err == nil {
+					t.Errorf("Kubeconfig with bad client key should be invalid")
+				}
+			},
+		},
+		{
+			func(c *Config) {
+				pki := utiltest.GeneratePKI(t)
+				c.ClientKey = types.PrivateKey(pki.PrivateKey)
+			},
+			func(err error, t *testing.T) {
+				if err == nil {
+					t.Errorf("Kubeconfig with not matching client key should be invalid")
+				}
+			},
+		},
+
+		{
+			func(c *Config) {},
+			func(err error, t *testing.T) {
+				if err != nil {
+					t.Errorf("Valid config shouldn't return error, got: %v", err)
+				}
+			},
+		},
+	}
+
+	for n, c := range cases {
+		c := c
+
+		t.Run(fmt.Sprintf("%d", n), func(t *testing.T) {
+			t.Parallel()
+
+			pki := utiltest.GeneratePKI(t)
+
+			config := &Config{
+				Server:            "localhost",
+				CACertificate:     types.Certificate(pki.Certificate),
+				ClientCertificate: types.Certificate(pki.Certificate),
+				ClientKey:         types.PrivateKey(pki.PrivateKey),
+			}
+
+			c.f(config)
+
+			_, err := config.ToYAMLString()
+
+			c.err(err, t)
+		})
+	}
+}
+func TestToYAMLStringValidate(t *testing.T) {
+	pki := utiltest.GeneratePKI(t)
+
+	c := &Config{
+		CACertificate:     types.Certificate(pki.Certificate),
+		ClientCertificate: types.Certificate(pki.Certificate),
+		ClientKey:         types.PrivateKey(pki.PrivateKey),
+	}
+
+	if _, err := c.ToYAMLString(); err == nil {
+		t.Fatalf("ToYAMLString should validate the configuration")
+	}
+}
+
+// Validate()
+func TestValidate(t *testing.T) {
+	cases := []struct {
+		f   func(*Config)
+		err func(error, *testing.T)
+	}{
+		{
+			func(c *Config) {
+				c.Server = ""
+			},
+			func(err error, t *testing.T) {
+				if err == nil {
+					t.Errorf("Kubeconfig without defined server should be invalid")
+				}
+			},
+		},
+		{
+			func(c *Config) {
+				c.CACertificate = ""
+			},
+			func(err error, t *testing.T) {
+				if err == nil {
+					t.Errorf("Kubeconfig without defined CA Certificate should be invalid")
+				}
+			},
+		},
+		{
+			func(c *Config) {
+				c.ClientCertificate = ""
+			},
+			func(err error, t *testing.T) {
+				if err == nil {
+					t.Errorf("Kubeconfig without defined client certificate should be invalid")
+				}
+			},
+		},
+		{
+			func(c *Config) {
+				c.ClientKey = ""
+			},
+			func(err error, t *testing.T) {
+				if err == nil {
+					t.Errorf("Kubeconfig without defined client key should be invalid")
+				}
+			},
+		},
+
+		{
+			func(c *Config) {},
+			func(err error, t *testing.T) {
+				if err != nil {
+					t.Errorf("Valid config shouldn't return error, got: %v", err)
+				}
+			},
+		},
+	}
+
+	for n, c := range cases {
+		c := c
+
+		t.Run(fmt.Sprintf("%d", n), func(t *testing.T) {
+			t.Parallel()
+
+			pki := utiltest.GeneratePKI(t)
+
+			config := &Config{
+				Server:            "localhost",
+				CACertificate:     types.Certificate(pki.Certificate),
+				ClientCertificate: types.Certificate(pki.Certificate),
+				ClientKey:         types.PrivateKey(pki.PrivateKey),
+			}
+
+			c.f(config)
+
+			c.err(config.Validate(), t)
+		})
 	}
 }

--- a/pkg/types/validate.go
+++ b/pkg/types/validate.go
@@ -1,0 +1,29 @@
+package types
+
+import (
+	"strings"
+)
+
+// ValidateError is a collection of errors, which can be used when
+// performing validation of structs to collect all possible errors
+// and return them in one batch.
+type ValidateError []error
+
+func (e ValidateError) Error() string {
+	errors := []string{}
+
+	for _, s := range e {
+		errors = append(errors, s.Error())
+	}
+
+	return strings.Join(errors, ", ")
+}
+
+// Return returns nil, if no errors has been added.
+func (e ValidateError) Return() error {
+	if len(e) > 0 {
+		return e
+	}
+
+	return nil
+}

--- a/pkg/types/validate_test.go
+++ b/pkg/types/validate_test.go
@@ -1,0 +1,22 @@
+package types
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestValidateError(t *testing.T) {
+	err := func() error {
+		errors := ValidateError{
+			fmt.Errorf("first error"),
+		}
+
+		errors = append(errors, fmt.Errorf("second error"))
+
+		return errors.Return()
+	}
+
+	if err == nil {
+		t.Fatalf("Error shouldn't be nil")
+	}
+}


### PR DESCRIPTION
This commit switches kube-scheduler and kube-controller-manager to use
kubeconfig helper for handling and use our types to automatically
validate fields.

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>