### PR TITLE
pkg/container: add support for specifying user and group for containers

### DIFF
--- a/pkg/container/hostconfiguredcontainer.go
+++ b/pkg/container/hostconfiguredcontainer.go
@@ -299,6 +299,8 @@ func (m *hostConfiguredContainer) copyConfigFiles(paths []string) error {
 			Path:    path.Join(ConfigMountpoint, p),
 			Content: content,
 			Mode:    configFileMode,
+			User:    m.container.Config().User,
+			Group:   m.container.Config().Group,
 		})
 	}
 

--- a/pkg/container/types/types.go
+++ b/pkg/container/types/types.go
@@ -15,6 +15,8 @@ type ContainerConfig struct {
 	NetworkMode string    `json:"networkMode,omitempty"`
 	PidMode     string    `json:"pidMode,omitempty"`
 	IpcMode     string    `json:"ipcMode,omitempty"`
+	User        string    `json:"user,omitempty"`
+	Group       string    `json:"group,omitempty"`
 }
 
 // ContainerStatus stores status information received from the runtime
@@ -46,6 +48,8 @@ type File struct {
 	Path    string `json:"path"`
 	Content string `json:"content"`
 	Mode    int64  `json:"mode"`
+	User    string `json:"uid"`
+	Group   string `json:"gid"`
 }
 
 func (s *ContainerStatus) Exists() bool {


### PR DESCRIPTION
So they can be run as unprivileged processes.

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>