### PR TITLE
Improve error messages, when there is nothing configured to do

### DIFF
--- a/pkg/apiloadbalancer/api-loadbalancers_test.go
+++ b/pkg/apiloadbalancer/api-loadbalancers_test.go
@@ -6,6 +6,16 @@ import (
 	"github.com/flexkube/libflexkube/pkg/types"
 )
 
+func TestPoolNoInstancesDefined(t *testing.T) {
+	a := &APILoadBalancers{}
+
+	if err := a.Validate(); err == nil {
+		t.Fatal("validate should fail if there is no instances defined and the state is empty")
+	} else {
+		t.Log(err)
+	}
+}
+
 func GetLoadBalancers(t *testing.T) types.Resource {
 	y := `
 ssh:

--- a/pkg/controlplane/controlplane.go
+++ b/pkg/controlplane/controlplane.go
@@ -296,13 +296,13 @@ func (c *Controlplane) Validate() error {
 
 	var errors util.ValidateError
 
-	if c.Destroy && c.State == nil {
+	if c.Destroy && (c.State == nil || len(*c.State) == 0) {
 		errors = append(errors, fmt.Errorf("can't destroy non-existent controlplane"))
 	}
 
 	cc := &container.Containers{}
 
-	if c.State != nil {
+	if c.State != nil && len(*c.State) > 0 {
 		cc.PreviousState = *c.State
 
 		if _, err := cc.New(); err != nil {

--- a/pkg/etcd/cluster.go
+++ b/pkg/etcd/cluster.go
@@ -128,8 +128,8 @@ func (c *Cluster) New() (types.Resource, error) {
 
 // Validate validates Cluster configuration.
 func (c *Cluster) Validate() error {
-	if len(c.Members) == 0 && c.State == nil {
-		return fmt.Errorf("either members or previous state needs to be defined")
+	if len(c.Members) == 0 && len(c.State) == 0 {
+		return fmt.Errorf("at least one member must be defined when state is empty")
 	}
 
 	var errors util.ValidateError

--- a/pkg/kubelet/pool_test.go
+++ b/pkg/kubelet/pool_test.go
@@ -182,3 +182,25 @@ func TestPoolPKIIntegration(t *testing.T) {
 		t.Fatalf("creating kubelet pool with PKI integration should work, got: %v", err)
 	}
 }
+
+func TestPoolNoKubelets(t *testing.T) {
+	pk := &pki.PKI{
+		Kubernetes: &pki.Kubernetes{},
+	}
+
+	if err := pk.Generate(); err != nil {
+		t.Fatalf("generating PKI: %v", err)
+	}
+
+	p := &Pool{
+		PKI: pk,
+		BootstrapConfig: &client.Config{
+			Server: "bar",
+			Token:  "bar",
+		},
+	}
+
+	if _, err := p.New(); err == nil {
+		t.Fatal("creating kubelet pool with no kubelets and no state defined should fail")
+	}
+}


### PR DESCRIPTION
This commit improves the error message in situation, when there is no
instances to configure and no instances to remove.

Closes #129

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>