### PR TITLE
Update default images and change default permissions for mountpoints to 0700 (required for updates)

### DIFF
--- a/pkg/container/hostconfiguredcontainer.go
+++ b/pkg/container/hostconfiguredcontainer.go
@@ -57,7 +57,7 @@ const (
 	configFileMode = 0o600
 
 	// mountpointDirMode is default host mountpoint directory permission.
-	mountpointDirMode = 0o755
+	mountpointDirMode = 0o700
 )
 
 // Hooks defines type of hooks HostConfiguredContainer supports.

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -3,7 +3,7 @@ package defaults
 
 const (
 	// EtcdImage points to a default Docker image, which will be used for running etcd.
-	EtcdImage = "quay.io/coreos/etcd:v3.4.9"
+	EtcdImage = "quay.io/coreos/etcd:v3.4.10"
 
 	// KubernetesImage is a default container image used for all kubernetes containers.
 	KubernetesImage = "k8s.gcr.io/hyperkube:v1.18.6"

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -6,7 +6,7 @@ const (
 	EtcdImage = "quay.io/coreos/etcd:v3.4.9"
 
 	// KubernetesImage is a default container image used for all kubernetes containers.
-	KubernetesImage = "k8s.gcr.io/hyperkube:v1.18.4"
+	KubernetesImage = "k8s.gcr.io/hyperkube:v1.18.6"
 
 	// HAProxyImage is a default container image for APILoadBalancer.
 	HAProxyImage = "haproxy:2.1.7-alpine"

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -9,7 +9,7 @@ const (
 	KubernetesImage = "k8s.gcr.io/hyperkube:v1.18.6"
 
 	// HAProxyImage is a default container image for APILoadBalancer.
-	HAProxyImage = "haproxy:2.1.7-alpine"
+	HAProxyImage = "haproxy:2.2.0-alpine"
 
 	// DockerAPIVersion is a default API version used when talking to Docker runtime.
 	DockerAPIVersion = "v1.38"


### PR DESCRIPTION
This PR updates default images used for Kubernetes, etcd and HAProxy. Also, new etcd version now requires stricter permissions on user data directory, so let's just change all default permissions to stricter, as it shouldn't have a negative impact.