### PR TITLE
Update golangci-lint to 1.30.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GORUN=$(GOCMD) run
 GOBUILD=CGO_ENABLED=$(CGO_ENABLED) $(GOCMD) build -v -buildmode=exe -ldflags $(LD_FLAGS)
 
 CC_TEST_REPORTER_ID=6e107e510c5479f40b0ce9166a254f3f1ee0bc547b3e48281bada1a5a32bb56d
-GOLANGCI_LINT_VERSION=v1.29.0
+GOLANGCI_LINT_VERSION=v1.30.0
 BIN_PATH=$$HOME/bin
 
 GO_PACKAGES=./...
@@ -29,7 +29,7 @@ BUILD_CMD=docker run -it --rm -v /home/core/libflexkube:/usr/src/libflexkube -v 
 
 BINARY_IMAGE=flexkube/libflexkube
 
-DISABLED_LINTERS=godox,lll,testpackage,goerr113
+DISABLED_LINTERS=godox,lll,testpackage,goerr113,gci
 
 TERRAFORM_BIN=$(TERRAFORM_ENV) /usr/bin/terraform
 

--- a/cmd/terraform-provider-flexkube/flexkube/resource_pki.go
+++ b/cmd/terraform-provider-flexkube/flexkube/resource_pki.go
@@ -75,6 +75,7 @@ func resourcePKICreate(d *schema.ResourceData, m interface{}) error {
 
 func resourcePKIDelete(d *schema.ResourceData, m interface{}) error {
 	d.SetId("")
+
 	return nil
 }
 

--- a/pkg/apiloadbalancer/api-loadbalancers.go
+++ b/pkg/apiloadbalancer/api-loadbalancers.go
@@ -175,12 +175,14 @@ func (a *APILoadBalancers) Validate() error {
 		lbx, err := lb.New()
 		if err != nil {
 			errors = append(errors, fmt.Errorf("failed creating load balancer instance %q: %w", i, err))
+
 			continue
 		}
 
 		lbxHcc, err := lbx.ToHostConfiguredContainer()
 		if err != nil {
 			errors = append(errors, fmt.Errorf("failed creating load balancer %q container configuration: %w", i, err))
+
 			continue
 		}
 

--- a/pkg/container/runtime/docker/docker.go
+++ b/pkg/container/runtime/docker/docker.go
@@ -217,6 +217,7 @@ func (d *docker) Start(id string) error {
 func (d *docker) Stop(id string) error {
 	// TODO make timeout configurable?
 	timeout := stopTimeout
+
 	return d.cli.ContainerStop(d.ctx, id, &timeout)
 }
 

--- a/pkg/etcd/cluster.go
+++ b/pkg/etcd/cluster.go
@@ -255,6 +255,7 @@ func (c *cluster) firstMember() (*member, error) {
 
 	for i := range c.members {
 		m = c.members[i]
+
 		break
 	}
 

--- a/pkg/etcd/member.go
+++ b/pkg/etcd/member.go
@@ -354,6 +354,7 @@ func (m *member) getEtcdClient(endpoints []string) (etcdClient, error) {
 		TLS: &tls.Config{
 			Certificates: []tls.Certificate{cert},
 			RootCAs:      p,
+			MinVersion:   tls.VersionTLS12,
 		},
 	})
 	if err != nil {

--- a/pkg/etcd/member_test.go
+++ b/pkg/etcd/member_test.go
@@ -69,6 +69,7 @@ func TestNewCluster(t *testing.T) {
 	for _, f := range hcc.Container.Config.Args {
 		if strings.Contains(f, "--initial-cluster-token") {
 			flag = true
+
 			break
 		}
 	}
@@ -93,6 +94,7 @@ func TestExistingCluster(t *testing.T) {
 	for _, f := range hcc.Container.Config.Args {
 		if strings.Contains(f, "--initial-cluster-state=existing") {
 			flag = true
+
 			break
 		}
 	}

--- a/pkg/helm/release/release_examples_test.go
+++ b/pkg/helm/release/release_examples_test.go
@@ -33,11 +33,13 @@ labels:
 	r, err := config.New()
 	if err != nil {
 		fmt.Printf("creating release object failed: %v\n", err)
+
 		return
 	}
 
 	if err := r.Install(); err != nil {
 		fmt.Printf("installing release failed: %v\n", err)
+
 		return
 	}
 }

--- a/pkg/host/transport/ssh/ssh.go
+++ b/pkg/host/transport/ssh/ssh.go
@@ -288,6 +288,7 @@ func forwardConnection(l net.Listener, connection dialer, remoteAddress, connect
 		remoteSock, err := connection.Dial(connectionType, remoteAddress)
 		if err != nil {
 			fmt.Printf("failed to open remote connection: %v\n", err)
+
 			return
 		}
 

--- a/pkg/kubelet/pool.go
+++ b/pkg/kubelet/pool.go
@@ -248,12 +248,14 @@ func (p *Pool) Validate() error {
 		kubelet, err := k.New()
 		if err != nil {
 			errors = append(errors, fmt.Errorf("failed to create kubelet object %q: %w", i, err))
+
 			continue
 		}
 
 		hcc, err := kubelet.ToHostConfiguredContainer()
 		if err != nil {
 			errors = append(errors, fmt.Errorf("failed to generate kubelet %q container configuration: %w", i, err))
+
 			continue
 		}
 

--- a/pkg/pki/pki.go
+++ b/pkg/pki/pki.go
@@ -397,6 +397,7 @@ func (c *Certificate) decodeKeyUsage() (x509.KeyUsage, []x509.ExtKeyUsage) {
 		r := int(keyUsage(k))
 		if r != 0 {
 			ku |= r
+
 			continue
 		}
 


### PR DESCRIPTION
* Disable new 'gci' linter, as we use different one for sorting imports
  and they contradict each other.
* Fix missing newline before return statements reported by new 'nlreturn' linter.
* Enforce TLS1.2 when talking to etcd API, recommended by gosec linter.
  Unfortunately, etcd does not support TLS1.3 yet.

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>