### PR TITLE
Revert "Upgrade to Terraform 0.13 and Kubernetes v1.19.0"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ flatcar_production_qemu_image.img
 flatcar_production_qemu_image.img.bz2
 *.auto.tfvars
 pool
+terraform-provider-ct
+terraform-provider-libvirt

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ INTEGRATION_CMD=docker run -it --rm -v /run:/run -v /home/core/libflexkube:/usr/
 
 E2E_IMAGE=flexkube/libflexkube-e2e
 
-E2E_CMD=docker run -it --rm -v /home/core/libflexkube:/root/libflexkube -v /home/core/.ssh:/root/.ssh -v /home/core/.terraform.d:/root/.terraform.d.host -v /home/core/libflexkube/bin/terraform-provider-flexkube:/root/.local/share/terraform/plugins/registry.terraform.io/flexkube-testing/flexkube/0.1.0/linux_amd64/terraform-provider-flexkube -w /root/libflexkube --net host --entrypoint /bin/bash -e TF_VAR_flatcar_channel=$(FLATCAR_CHANNEL) -e TF_VAR_controllers_count=$(CONTROLLERS) -e TF_VAR_workers_count=$(WORKERS) -e TF_VAR_nodes_cidr=$(NODES_CIDR) $(E2E_IMAGE)
+E2E_CMD=docker run -it --rm -v /home/core/libflexkube:/root/libflexkube -v /home/core/.ssh:/root/.ssh -v /home/core/.terraform.d:/root/.terraform.d.host -v /home/core/libflexkube/bin/terraform-provider-flexkube:/root/.terraform.d/plugins/terraform-provider-flexkube -w /root/libflexkube --net host --entrypoint /bin/bash -e TF_VAR_flatcar_channel=$(FLATCAR_CHANNEL) -e TF_VAR_controllers_count=$(CONTROLLERS) -e TF_VAR_workers_count=$(WORKERS) -e TF_VAR_nodes_cidr=$(NODES_CIDR) $(E2E_IMAGE)
 
 BUILD_CMD=docker run -it --rm -v /home/core/libflexkube:/usr/src/libflexkube -v /home/core/go:/go -v /home/core/.cache:/root/.cache -v /run:/run -w /usr/src/libflexkube $(INTEGRATION_IMAGE)
 
@@ -132,8 +132,7 @@ test-local:
 
 .PHONY: test-local-apply
 test-local-apply:
-	mkdir -p local-testing/.terraform/plugins/registry.terraform.io/flexkube-testing/flexkube/0.1.0/linux_amd64/
-	cd cmd/terraform-provider-flexkube && $(GOBUILD) -o ../../local-testing/.terraform/plugins/registry.terraform.io/flexkube-testing/flexkube/0.1.0/linux_amd64/terraform-provider-flexkube
+	cd cmd/terraform-provider-flexkube && $(GOBUILD) -o ../../local-testing/terraform-provider-flexkube
 	cd local-testing && $(TERRAFORM_BIN) init && $(TERRAFORM_BIN) apply -auto-approve
 
 .PHONY: test-conformance
@@ -297,6 +296,11 @@ libvirt-download-image:
 	((test -f libvirt/flatcar_production_qemu_image.img.bz2 || test -f libvirt/flatcar_production_qemu_image.img) || wget https://$(FLATCAR_CHANNEL).release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.bz2 -O libvirt/flatcar_production_qemu_image.img.bz2) || true
 	(test -f libvirt/flatcar_production_qemu_image.img.bz2 && bunzip2 libvirt/flatcar_production_qemu_image.img.bz2 && rm libvirt/flatcar_production_qemu_image.img.bz2) || true
 	qemu-img resize libvirt/flatcar_production_qemu_image.img +5G
+
+.PHONY: libvirt-download-providers
+libvirt-download-providers:
+	test -f libvirt/terraform-provider-libvirt || (wget https://github.com/dmacvicar/terraform-provider-libvirt/releases/download/v0.6.1/terraform-provider-libvirt-0.6.1+git.1578064534.db13b678.Fedora_28.x86_64.tar.gz -O libvirt/provider.tar.gz && tar zxvf libvirt/provider.tar.gz && rm libvirt/provider.tar.gz && mv terraform-provider-libvirt ./libvirt/)
+	test -f libvirt/terraform-provider-ct || (wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.4.0/terraform-provider-ct-v0.4.0-linux-amd64.tar.gz -O libvirt/provider.tar.gz && tar xzf libvirt/provider.tar.gz && rm libvirt/provider.tar.gz && mv terraform-provider-ct-v0.4.0-linux-amd64/terraform-provider-ct ./libvirt/ && rmdir terraform-provider-ct-v0.4.0-linux-amd64)
 
 .PHONY: test-static
 test-static:

--- a/e2e/versions.tf
+++ b/e2e/versions.tf
@@ -1,22 +1,7 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 0.12.0"
+}
 
-  required_providers {
-    null = {
-      source  = "hashicorp/null"
-      version = "2.1.2"
-    }
-    local = {
-      source  = "hashicorp/local"
-      version = "1.4.0"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = "2.2.1"
-    }
-    flexkube = {
-      source  = "flexkube-testing/flexkube"
-      version = "0.1.0"
-    }
-  }
+provider "null" {
+  version = "= 2.1.2"
 }

--- a/libvirt/main.tf
+++ b/libvirt/main.tf
@@ -1,5 +1,10 @@
 provider "libvirt" {
-  uri = "qemu:///system"
+  version = "~> 0.6.0"
+  uri     = "qemu:///system"
+}
+
+provider "ct" {
+  version = "= 0.4.0"
 }
 
 variable "core_public_keys" {

--- a/libvirt/versions.tf
+++ b/libvirt/versions.tf
@@ -1,18 +1,1 @@
-terraform {
-  required_version = ">= 0.13"
-
-  required_providers {
-    null = {
-      source  = "hashicorp/null"
-      version = "2.1.2"
-    }
-    libvirt = {
-      source  = "dmacvicar/libvirt"
-      version = "0.6.2"
-    }
-    ct = {
-      source  = "poseidon/ct"
-      version = "0.6.1"
-    }
-  }
-}
+../e2e/versions.tf

--- a/pkg/controlplane/controlplane.go
+++ b/pkg/controlplane/controlplane.go
@@ -38,6 +38,11 @@ type Common struct {
 	FrontProxyCACertificate types.Certificate `json:"frontProxyCACertificate,omitempty"`
 }
 
+// GetImage returns either image defined in common config or Kubernetes default image.
+func (co Common) GetImage() string {
+	return util.PickString(co.Image, defaults.KubernetesImage)
+}
+
 // Controlplane allows creating static Kubernetes controlplane running as containers.
 //
 // It is usually used to bootstrap self-hosted Kubernetes.

--- a/pkg/controlplane/controlplane_test.go
+++ b/pkg/controlplane/controlplane_test.go
@@ -120,6 +120,25 @@ func TestControlplaneFromYaml(t *testing.T) {
 	}
 }
 
+// GetImage() tests.
+func TestCommonGetImage(t *testing.T) {
+	c := Common{}
+	if a := c.GetImage(); a == "" {
+		t.Fatalf("GetImage() should always return at least default image")
+	}
+}
+
+func TestCommonGetImageSpecified(t *testing.T) {
+	i := "foo"
+	c := Common{
+		Image: i,
+	}
+
+	if a := c.GetImage(); a != i {
+		t.Fatalf("GetImage() should return specified image, if it's defined")
+	}
+}
+
 // New() tests.
 func TestControlplaneNewValidate(t *testing.T) {
 	c := &Controlplane{}

--- a/pkg/controlplane/kube-apiserver.go
+++ b/pkg/controlplane/kube-apiserver.go
@@ -9,7 +9,6 @@ import (
 	"github.com/flexkube/libflexkube/pkg/container"
 	"github.com/flexkube/libflexkube/pkg/container/runtime/docker"
 	containertypes "github.com/flexkube/libflexkube/pkg/container/types"
-	"github.com/flexkube/libflexkube/pkg/defaults"
 	"github.com/flexkube/libflexkube/pkg/host"
 	"github.com/flexkube/libflexkube/pkg/types"
 )
@@ -214,8 +213,6 @@ func (k *kubeAPIServer) args() []string {
 		"--enable-admission-plugins=NodeRestriction,PodSecurityPolicy",
 		// To limit memory consumption of bootstrap controlplane, limit it to 512 MB.
 		"--target-ram-mb=512",
-		// Use SO_REUSEPORT, so multiple instances can run on the same controller for smooth upgrades.
-		"--permit-port-sharing=true",
 	}
 }
 
@@ -230,13 +227,19 @@ func (k *kubeAPIServer) ToHostConfiguredContainer() (*container.HostConfiguredCo
 				Docker: docker.DefaultConfig(),
 			},
 			Config: containertypes.ContainerConfig{
-				Name:        containerName,
-				Image:       util.PickString(k.common.Image, defaults.KubeAPIServerImage),
-				NetworkMode: "host",
+				Name:  containerName,
+				Image: k.common.GetImage(),
 				Mounts: []containertypes.Mount{
 					{
 						Source: hostConfigPath,
 						Target: containerConfigPath,
+					},
+				},
+				Ports: []containertypes.PortMap{
+					{
+						IP:       k.bindAddress,
+						Protocol: "tcp",
+						Port:     k.securePort,
 					},
 				},
 				Args: k.args(),

--- a/pkg/controlplane/kube-controller-manager.go
+++ b/pkg/controlplane/kube-controller-manager.go
@@ -3,11 +3,9 @@ package controlplane
 import (
 	"fmt"
 
-	"github.com/flexkube/libflexkube/internal/util"
 	"github.com/flexkube/libflexkube/pkg/container"
 	"github.com/flexkube/libflexkube/pkg/container/runtime/docker"
 	containertypes "github.com/flexkube/libflexkube/pkg/container/types"
-	"github.com/flexkube/libflexkube/pkg/defaults"
 	"github.com/flexkube/libflexkube/pkg/host"
 	"github.com/flexkube/libflexkube/pkg/kubernetes/client"
 	"github.com/flexkube/libflexkube/pkg/types"
@@ -116,7 +114,7 @@ func (k *kubeControllerManager) ToHostConfiguredContainer() (*container.HostConf
 		},
 		Config: containertypes.ContainerConfig{
 			Name:  "kube-controller-manager",
-			Image: util.PickString(k.common.Image, defaults.KubeControllerManagerImage),
+			Image: k.common.GetImage(),
 			Mounts: []containertypes.Mount{
 				{
 					Source: "/etc/kubernetes/kube-controller-manager/",

--- a/pkg/controlplane/kube-scheduler.go
+++ b/pkg/controlplane/kube-scheduler.go
@@ -3,11 +3,9 @@ package controlplane
 import (
 	"fmt"
 
-	"github.com/flexkube/libflexkube/internal/util"
 	"github.com/flexkube/libflexkube/pkg/container"
 	"github.com/flexkube/libflexkube/pkg/container/runtime/docker"
 	containertypes "github.com/flexkube/libflexkube/pkg/container/types"
-	"github.com/flexkube/libflexkube/pkg/defaults"
 	"github.com/flexkube/libflexkube/pkg/host"
 	"github.com/flexkube/libflexkube/pkg/kubernetes/client"
 )
@@ -39,7 +37,7 @@ func (k *kubeScheduler) ToHostConfiguredContainer() (*container.HostConfiguredCo
 	configFiles["/etc/kubernetes/kube-scheduler/kubeconfig"] = k.kubeconfig
 	configFiles["/etc/kubernetes/kube-scheduler/pki/ca.crt"] = string(k.common.KubernetesCACertificate)
 	configFiles["/etc/kubernetes/kube-scheduler/pki/front-proxy-ca.crt"] = string(k.common.FrontProxyCACertificate)
-	configFiles["/etc/kubernetes/kube-scheduler/kube-scheduler.yaml"] = `apiVersion: kubescheduler.config.k8s.io/v1beta1
+	configFiles["/etc/kubernetes/kube-scheduler/kube-scheduler.yaml"] = `apiVersion: kubescheduler.config.k8s.io/v1alpha1
 kind: KubeSchedulerConfiguration
 clientConnection:
   kubeconfig: /etc/kubernetes/kubeconfig
@@ -52,7 +50,7 @@ clientConnection:
 		},
 		Config: containertypes.ContainerConfig{
 			Name:  "kube-scheduler",
-			Image: util.PickString(k.common.Image, defaults.KubeSchedulerImage),
+			Image: k.common.GetImage(),
 			Mounts: []containertypes.Mount{
 				{
 					Source: "/etc/kubernetes/kube-scheduler/",

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -3,23 +3,10 @@ package defaults
 
 const (
 	// EtcdImage points to a default Docker image, which will be used for running etcd.
-	EtcdImage = "quay.io/coreos/etcd:v3.4.13"
+	EtcdImage = "quay.io/coreos/etcd:v3.4.11"
 
-	// KubeAPIServerImage points to a default Docker image, which will be used for
-	// running kube-apiserver.
-	KubeAPIServerImage = "k8s.gcr.io/kube-apiserver:v1.19.0"
-
-	// KubeControllerManagerImage points to a default Docker image, which will be used for
-	// running kube-apiserver.
-	KubeControllerManagerImage = "k8s.gcr.io/kube-controller-manager:v1.19.0"
-
-	// KubeSchedulerImage points to a default Docker image, which will be used for
-	// running kube-apiserver.
-	KubeSchedulerImage = "k8s.gcr.io/kube-scheduler:v1.19.0"
-
-	// KubeletImage points to a default Docker image, which will be used for
-	// running kube-apiserver.
-	KubeletImage = "quay.io/flexkube/kubelet:v1.19.0"
+	// KubernetesImage is a default container image used for all kubernetes containers.
+	KubernetesImage = "k8s.gcr.io/hyperkube:v1.18.8"
 
 	// HAProxyImage is a default container image for APILoadBalancer.
 	HAProxyImage = "haproxy:2.2.2-alpine"

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -132,7 +132,7 @@ func (k *Kubelet) New() (container.ResourceInstance, error) {
 	}
 
 	if nk.config.Image == "" {
-		nk.config.Image = defaults.KubeletImage
+		nk.config.Image = defaults.KubernetesImage
 	}
 
 	return nk, nil
@@ -422,6 +422,7 @@ func (k *kubelet) mounts() []containertypes.Mount { //nolint:funlen
 
 func (k *kubelet) args() []string {
 	a := []string{
+		"kubelet",
 		// Tell kubelet to use config file.
 		"--config=/etc/kubernetes/kubelet.yaml",
 		// Specify kubeconfig file for kubelet. This enabled API server mode and


### PR DESCRIPTION
Reverts flexkube/libflexkube#164

Reverting those changes temporarily, so we can have one more 0.3.x release with Kubernetes 1.18.x to submit conformance tests.

Doing revert instead of release branch to avoid duplicating work etc.