### PR TITLE
Revert revert of Terraform 0.13 and Kubernetes 1.19, fix typos and add releasing process documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,3 @@ flatcar_production_qemu_image.img
 flatcar_production_qemu_image.img.bz2
 *.auto.tfvars
 pool
-terraform-provider-ct
-terraform-provider-libvirt

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ INTEGRATION_CMD=docker run -it --rm -v /run:/run -v /home/core/libflexkube:/usr/
 
 E2E_IMAGE=flexkube/libflexkube-e2e
 
-E2E_CMD=docker run -it --rm -v /home/core/libflexkube:/root/libflexkube -v /home/core/.ssh:/root/.ssh -v /home/core/.terraform.d:/root/.terraform.d.host -v /home/core/libflexkube/bin/terraform-provider-flexkube:/root/.terraform.d/plugins/terraform-provider-flexkube -w /root/libflexkube --net host --entrypoint /bin/bash -e TF_VAR_flatcar_channel=$(FLATCAR_CHANNEL) -e TF_VAR_controllers_count=$(CONTROLLERS) -e TF_VAR_workers_count=$(WORKERS) -e TF_VAR_nodes_cidr=$(NODES_CIDR) $(E2E_IMAGE)
+E2E_CMD=docker run -it --rm -v /home/core/libflexkube:/root/libflexkube -v /home/core/.ssh:/root/.ssh -v /home/core/.terraform.d:/root/.terraform.d.host -v /home/core/libflexkube/bin/terraform-provider-flexkube:/root/.local/share/terraform/plugins/registry.terraform.io/flexkube-testing/flexkube/0.1.0/linux_amd64/terraform-provider-flexkube -w /root/libflexkube --net host --entrypoint /bin/bash -e TF_VAR_flatcar_channel=$(FLATCAR_CHANNEL) -e TF_VAR_controllers_count=$(CONTROLLERS) -e TF_VAR_workers_count=$(WORKERS) -e TF_VAR_nodes_cidr=$(NODES_CIDR) $(E2E_IMAGE)
 
 BUILD_CMD=docker run -it --rm -v /home/core/libflexkube:/usr/src/libflexkube -v /home/core/go:/go -v /home/core/.cache:/root/.cache -v /run:/run -w /usr/src/libflexkube $(INTEGRATION_IMAGE)
 
@@ -132,7 +132,8 @@ test-local:
 
 .PHONY: test-local-apply
 test-local-apply:
-	cd cmd/terraform-provider-flexkube && $(GOBUILD) -o ../../local-testing/terraform-provider-flexkube
+	mkdir -p local-testing/.terraform/plugins/registry.terraform.io/flexkube-testing/flexkube/0.1.0/linux_amd64/
+	cd cmd/terraform-provider-flexkube && $(GOBUILD) -o ../../local-testing/.terraform/plugins/registry.terraform.io/flexkube-testing/flexkube/0.1.0/linux_amd64/terraform-provider-flexkube
 	cd local-testing && $(TERRAFORM_BIN) init && $(TERRAFORM_BIN) apply -auto-approve
 
 .PHONY: test-conformance
@@ -298,11 +299,6 @@ libvirt-download-image:
 	((test -f libvirt/flatcar_production_qemu_image.img.bz2 || test -f libvirt/flatcar_production_qemu_image.img) || wget https://$(FLATCAR_CHANNEL).release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.bz2 -O libvirt/flatcar_production_qemu_image.img.bz2) || true
 	(test -f libvirt/flatcar_production_qemu_image.img.bz2 && bunzip2 libvirt/flatcar_production_qemu_image.img.bz2 && rm libvirt/flatcar_production_qemu_image.img.bz2) || true
 	qemu-img resize libvirt/flatcar_production_qemu_image.img +5G
-
-.PHONY: libvirt-download-providers
-libvirt-download-providers:
-	test -f libvirt/terraform-provider-libvirt || (wget https://github.com/dmacvicar/terraform-provider-libvirt/releases/download/v0.6.1/terraform-provider-libvirt-0.6.1+git.1578064534.db13b678.Fedora_28.x86_64.tar.gz -O libvirt/provider.tar.gz && tar zxvf libvirt/provider.tar.gz && rm libvirt/provider.tar.gz && mv terraform-provider-libvirt ./libvirt/)
-	test -f libvirt/terraform-provider-ct || (wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.4.0/terraform-provider-ct-v0.4.0-linux-amd64.tar.gz -O libvirt/provider.tar.gz && tar xzf libvirt/provider.tar.gz && rm libvirt/provider.tar.gz && mv terraform-provider-ct-v0.4.0-linux-amd64/terraform-provider-ct ./libvirt/ && rmdir terraform-provider-ct-v0.4.0-linux-amd64)
 
 .PHONY: test-static
 test-static:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,38 @@
+# libflexkube release process
+
+This document briefly describes the process of releasing new version of libflexkube.
+
+## Before the release
+
+Before creating a Git tag and a GitHub release, following tasks should be performed:
+
+- Changelog for the new version should be added to CHANGELOG.md file.
+- Changelog link should be added at the bottom of CHANGELOG.md file.
+- `Version` constant in `cli/flexkube/cli.go` file should be changed to version which will be released and change should be committed. This commit will be later on tagged while releasing, so it should be done as last action before the release.
+- `Version` constant in `cli/flexkube/cli.go` file should be changed to next version with `-unreleased` suffix and change should be committed. This commit will be the first commit of the next release.
+- Conformance tests (e.g. `make vagrant-conformance`) should be performed on the release commit before creating an actual release to ensure the release is working properly.
+- Pull Request with described changes should be created and merged.
+
+## Creating the release
+
+To create new release, following tasks should be performed:
+
+- Tag new release on desired commit with CLI version changed, using example command:
+
+  ```sh
+  git tag -a v0.4.7 -s -m "Release v0.4.7" <commit hash>
+  ```
+
+- Push tag to GitHub:
+
+  ```sh
+  git push upstream v0.4.7
+  ```
+
+- Run `goreleaser` to create a GitHub Release:
+
+  ```sh
+  GITHUB_TOKEN=githubtoken goreleaser release --release-notes <(go run github.com/rcmachado/changelog show 0.4.7)
+  ```
+
+- Go to newly create [GitHub release](https://github.com/flexkube/libflexkube/releases/tag/v0.4.7), verify that the changelog and artifacts looks correct and publish it.

--- a/e2e/templates/kube-apiserver-values.yaml.tmpl
+++ b/e2e/templates/kube-apiserver-values.yaml.tmpl
@@ -1,5 +1,3 @@
-image: k8s.gcr.io/hyperkube:v1.18.8
-
 serverKey: |
   ${indent(2, trimspace(server_key))}
 serverCertificate: |

--- a/e2e/templates/values.yaml.tmpl
+++ b/e2e/templates/values.yaml.tmpl
@@ -1,4 +1,3 @@
-image: k8s.gcr.io/hyperkube:v1.18.8
 serviceAccountPrivateKey: |
   ${indent(2, trimspace(service_account_private_key))}
 kubernetesCAKey: |

--- a/e2e/variables.tf
+++ b/e2e/variables.tf
@@ -51,15 +51,15 @@ variable "calico_helm_chart_source" {
 }
 
 variable "kube_apiserver_helm_chart_version" {
-  default = "0.1.14"
+  default = "0.2.0"
 }
 
 variable "kubernetes_helm_chart_version" {
-  default = "0.2.3"
+  default = "0.3.1"
 }
 
 variable "kube_proxy_helm_chart_version" {
-  default = "0.2.0"
+  default = "0.2.1"
 }
 
 variable "tls_bootstrapping_helm_chart_version" {

--- a/e2e/variables.tf
+++ b/e2e/variables.tf
@@ -79,7 +79,7 @@ variable "kubelet_rubber_stamp_helm_chart_version" {
 }
 
 variable "calico_helm_chart_version" {
-  default = "0.2.3"
+  default = "0.2.4"
 }
 
 variable "flatcar_channel" {

--- a/e2e/versions.tf
+++ b/e2e/versions.tf
@@ -1,7 +1,22 @@
 terraform {
-  required_version = "~> 0.12.0"
-}
+  required_version = ">= 0.13"
 
-provider "null" {
-  version = "= 2.1.2"
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "2.1.2"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "1.4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "2.2.1"
+    }
+    flexkube = {
+      source  = "flexkube-testing/flexkube"
+      version = "0.1.0"
+    }
+  }
 }

--- a/libvirt/main.tf
+++ b/libvirt/main.tf
@@ -1,10 +1,5 @@
 provider "libvirt" {
-  version = "~> 0.6.0"
-  uri     = "qemu:///system"
-}
-
-provider "ct" {
-  version = "= 0.4.0"
+  uri = "qemu:///system"
 }
 
 variable "core_public_keys" {

--- a/libvirt/versions.tf
+++ b/libvirt/versions.tf
@@ -1,1 +1,18 @@
-../e2e/versions.tf
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "2.1.2"
+    }
+    libvirt = {
+      source  = "dmacvicar/libvirt"
+      version = "0.6.2"
+    }
+    ct = {
+      source  = "poseidon/ct"
+      version = "0.6.1"
+    }
+  }
+}

--- a/pkg/controlplane/controlplane.go
+++ b/pkg/controlplane/controlplane.go
@@ -38,11 +38,6 @@ type Common struct {
 	FrontProxyCACertificate types.Certificate `json:"frontProxyCACertificate,omitempty"`
 }
 
-// GetImage returns either image defined in common config or Kubernetes default image.
-func (co Common) GetImage() string {
-	return util.PickString(co.Image, defaults.KubernetesImage)
-}
-
 // Controlplane allows creating static Kubernetes controlplane running as containers.
 //
 // It is usually used to bootstrap self-hosted Kubernetes.

--- a/pkg/controlplane/controlplane_test.go
+++ b/pkg/controlplane/controlplane_test.go
@@ -120,25 +120,6 @@ func TestControlplaneFromYaml(t *testing.T) {
 	}
 }
 
-// GetImage() tests.
-func TestCommonGetImage(t *testing.T) {
-	c := Common{}
-	if a := c.GetImage(); a == "" {
-		t.Fatalf("GetImage() should always return at least default image")
-	}
-}
-
-func TestCommonGetImageSpecified(t *testing.T) {
-	i := "foo"
-	c := Common{
-		Image: i,
-	}
-
-	if a := c.GetImage(); a != i {
-		t.Fatalf("GetImage() should return specified image, if it's defined")
-	}
-}
-
 // New() tests.
 func TestControlplaneNewValidate(t *testing.T) {
 	c := &Controlplane{}

--- a/pkg/controlplane/kube-controller-manager.go
+++ b/pkg/controlplane/kube-controller-manager.go
@@ -3,9 +3,11 @@ package controlplane
 import (
 	"fmt"
 
+	"github.com/flexkube/libflexkube/internal/util"
 	"github.com/flexkube/libflexkube/pkg/container"
 	"github.com/flexkube/libflexkube/pkg/container/runtime/docker"
 	containertypes "github.com/flexkube/libflexkube/pkg/container/types"
+	"github.com/flexkube/libflexkube/pkg/defaults"
 	"github.com/flexkube/libflexkube/pkg/host"
 	"github.com/flexkube/libflexkube/pkg/kubernetes/client"
 	"github.com/flexkube/libflexkube/pkg/types"
@@ -114,7 +116,7 @@ func (k *kubeControllerManager) ToHostConfiguredContainer() (*container.HostConf
 		},
 		Config: containertypes.ContainerConfig{
 			Name:  "kube-controller-manager",
-			Image: k.common.GetImage(),
+			Image: util.PickString(k.common.Image, defaults.KubeControllerManagerImage),
 			Mounts: []containertypes.Mount{
 				{
 					Source: "/etc/kubernetes/kube-controller-manager/",

--- a/pkg/controlplane/kube-scheduler.go
+++ b/pkg/controlplane/kube-scheduler.go
@@ -3,9 +3,11 @@ package controlplane
 import (
 	"fmt"
 
+	"github.com/flexkube/libflexkube/internal/util"
 	"github.com/flexkube/libflexkube/pkg/container"
 	"github.com/flexkube/libflexkube/pkg/container/runtime/docker"
 	containertypes "github.com/flexkube/libflexkube/pkg/container/types"
+	"github.com/flexkube/libflexkube/pkg/defaults"
 	"github.com/flexkube/libflexkube/pkg/host"
 	"github.com/flexkube/libflexkube/pkg/kubernetes/client"
 )
@@ -37,7 +39,7 @@ func (k *kubeScheduler) ToHostConfiguredContainer() (*container.HostConfiguredCo
 	configFiles["/etc/kubernetes/kube-scheduler/kubeconfig"] = k.kubeconfig
 	configFiles["/etc/kubernetes/kube-scheduler/pki/ca.crt"] = string(k.common.KubernetesCACertificate)
 	configFiles["/etc/kubernetes/kube-scheduler/pki/front-proxy-ca.crt"] = string(k.common.FrontProxyCACertificate)
-	configFiles["/etc/kubernetes/kube-scheduler/kube-scheduler.yaml"] = `apiVersion: kubescheduler.config.k8s.io/v1alpha1
+	configFiles["/etc/kubernetes/kube-scheduler/kube-scheduler.yaml"] = `apiVersion: kubescheduler.config.k8s.io/v1beta1
 kind: KubeSchedulerConfiguration
 clientConnection:
   kubeconfig: /etc/kubernetes/kubeconfig
@@ -50,7 +52,7 @@ clientConnection:
 		},
 		Config: containertypes.ContainerConfig{
 			Name:  "kube-scheduler",
-			Image: k.common.GetImage(),
+			Image: util.PickString(k.common.Image, defaults.KubeSchedulerImage),
 			Mounts: []containertypes.Mount{
 				{
 					Source: "/etc/kubernetes/kube-scheduler/",

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -5,8 +5,21 @@ const (
 	// EtcdImage points to a default Docker image, which will be used for running etcd.
 	EtcdImage = "quay.io/coreos/etcd:v3.4.13"
 
-	// KubernetesImage is a default container image used for all kubernetes containers.
-	KubernetesImage = "k8s.gcr.io/hyperkube:v1.18.8"
+	// KubeAPIServerImage points to a default Docker image, which will be used for
+	// running kube-apiserver.
+	KubeAPIServerImage = "k8s.gcr.io/kube-apiserver:v1.19.0"
+
+	// KubeControllerManagerImage points to a default Docker image, which will be used for
+	// running kube-apiserver.
+	KubeControllerManagerImage = "k8s.gcr.io/kube-controller-manager:v1.19.0"
+
+	// KubeSchedulerImage points to a default Docker image, which will be used for
+	// running kube-apiserver.
+	KubeSchedulerImage = "k8s.gcr.io/kube-scheduler:v1.19.0"
+
+	// KubeletImage points to a default Docker image, which will be used for
+	// running kube-apiserver.
+	KubeletImage = "quay.io/flexkube/kubelet:v1.19.0"
 
 	// HAProxyImage is a default container image for APILoadBalancer.
 	HAProxyImage = "haproxy:2.2.2-alpine"

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -132,7 +132,7 @@ func (k *Kubelet) New() (container.ResourceInstance, error) {
 	}
 
 	if nk.config.Image == "" {
-		nk.config.Image = defaults.KubernetesImage
+		nk.config.Image = defaults.KubeletImage
 	}
 
 	return nk, nil
@@ -422,7 +422,6 @@ func (k *kubelet) mounts() []containertypes.Mount { //nolint:funlen
 
 func (k *kubelet) args() []string {
 	a := []string{
-		"kubelet",
 		// Tell kubelet to use config file.
 		"--config=/etc/kubernetes/kubelet.yaml",
 		// Specify kubeconfig file for kubelet. This enabled API server mode and

--- a/pkg/pki/pki.go
+++ b/pkg/pki/pki.go
@@ -450,13 +450,13 @@ func (c *Certificate) generateX509Certificate(k *rsa.PrivateKey, ca *Certificate
 
 		caCert, pk, err = ca.decodeKeypair()
 		if err != nil {
-			return fmt.Errorf("failed to decode CA keypair: %w", err)
+			return fmt.Errorf("failed to decode CA key pair: %w", err)
 		}
 	}
 
 	subjectKeyID, err := bigIntHash(pk.N)
 	if err != nil {
-		return fmt.Errorf("failed generating certificate subjet Key ID: %w", err)
+		return fmt.Errorf("failed generating certificate subject Key ID: %w", err)
 	}
 
 	cert.SubjectKeyId = subjectKeyID

--- a/pkg/pki/pki_test.go
+++ b/pkg/pki/pki_test.go
@@ -65,7 +65,7 @@ func TestGenerateTrustChain(t *testing.T) {
 	block, _ := pem.Decode([]byte(pki.Etcd.PeerCertificates["controller01"].X509Certificate))
 	if block == nil {
 		// It seems staticcheck linter do not recognize t.Fatal() as a flow breaking statement,
-		// so then it yells that we might dereference unitialized 'block' variable, which is not
+		// so then it yells that we might dereference uninitialized 'block' variable, which is not
 		// true, so just use t.Fatalf() to silence it.
 		//
 		// The alternative would be to add bare 'return' after this call, which seems even more ugly.


### PR DESCRIPTION
Also update Calico chart to the latest version.

Closes #133.