### PR TITLE
pkg/container: improve handling missing host situation

### DIFF
--- a/pkg/container/containersstate_test.go
+++ b/pkg/container/containersstate_test.go
@@ -71,8 +71,16 @@ func TestContainersStateCheckStateFailStatus(t *testing.T) {
 		},
 	}
 
-	if err := c.CheckState(); err == nil {
-		t.Fatalf("Should fail with failing status")
+	if err := c.CheckState(); err != nil {
+		t.Fatalf("Should not fail with failing status")
+	}
+
+	if c["foo"].container.Status().ID != "" {
+		t.Errorf("failing status call should reset container ID, so we assume container is gone")
+	}
+
+	if c["foo"].container.Status().Status == "fail" {
+		t.Errorf("container status should include error message returned by status function")
 	}
 }
 

--- a/pkg/container/hostconfiguredcontainer.go
+++ b/pkg/container/hostconfiguredcontainer.go
@@ -456,7 +456,7 @@ func (m *hostConfiguredContainer) Create() error {
 func (m *hostConfiguredContainer) Status() error {
 	// If container does not exist, skip checking the status of it, as it won't work.
 	if !m.container.Status().Exists() {
-		return nil
+		return fmt.Errorf("can't check status of non existing container")
 	}
 
 	return m.withForwardedRuntime(m.container.UpdateStatus)

--- a/pkg/container/hostconfiguredcontainer_test.go
+++ b/pkg/container/hostconfiguredcontainer_test.go
@@ -109,8 +109,8 @@ func TestHostConfiguredContainerStatusNotExist(t *testing.T) {
 		container: &container{},
 	}
 
-	if err := h.Status(); err != nil {
-		t.Fatalf("checking status of non existing container should succeed, got: %v", err)
+	if err := h.Status(); err == nil {
+		t.Fatalf("checking status of non existing container should fail, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
Currently, if host running a container is lost, managing containers will
get stuck until lost container is removed manually from state.

This commit modifies the logic, so now in case where host which runs the
container cannot be reached, the error messages is added to the
container state and refreshing the state no longer returns error.

This allow user to inspect the state of a given container and decide
either to accept that that container is missing or abort and
investigate.

This should allow cleaning up the state gracefully even if all container
machines no longer exists.

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>