### PR TITLE
e2e: update flexkube/metrics-server to latest version

### DIFF
--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -107,7 +107,7 @@ func defaultE2EConfig(t *testing.T) e2eConfig {
 			},
 			MetricsServer: chart{
 				Source:  "flexkube/metrics-server",
-				Version: "3.0.0",
+				Version: "3.0.1",
 			},
 			KubeletRubberStamp: chart{
 				Source:  "flexkube/kubelet-rubber-stamp",


### PR DESCRIPTION
3.0.0 ended up being buggy and pointing to non-existing image.

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>