### PR TITLE
Update golangci-lint to v1.33.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,8 @@
+issues:
+  exclude-rules:
+    - linters:
+      - paralleltest
+      text: "does not use range value in test Run"
+    - linters:
+      - godot
+      source: "(front proxy CA certificate,|certificate, as recommended by)"

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GORUN=$(GOCMD) run
 GOBUILD=$(GOCMD) build -v -buildmode=exe -ldflags $(LD_FLAGS)
 
 CC_TEST_REPORTER_ID=6e107e510c5479f40b0ce9166a254f3f1ee0bc547b3e48281bada1a5a32bb56d
-GOLANGCI_LINT_VERSION=v1.32.1
+GOLANGCI_LINT_VERSION=v1.33.0
 BIN_PATH=$$HOME/bin
 
 GO_PACKAGES=./...
@@ -141,7 +141,7 @@ test-conformance-clean:
 
 .PHONY: lint
 lint:
-	golangci-lint run --enable-all --disable=$(DISABLED_LINTERS) --max-same-issues=0 --max-issues-per-linter=0 --build-tags integration,e2e --timeout 10m --exclude-use-default=false $(GO_PACKAGES)
+	golangci-lint run --enable-all --disable=$(DISABLED_LINTERS) --max-same-issues=0 --max-issues-per-linter=0 --build-tags integration,e2e --timeout 10m --exclude-use-default=false --sort-results $(GO_PACKAGES)
 
 .PHONY: update
 update:

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -121,7 +121,7 @@ func defaultE2EConfig(t *testing.T) e2eConfig {
 	}
 }
 
-//nolint:funlen,gocognit,gocyclo
+//nolint:funlen,gocognit,gocyclo,paralleltest
 func TestE2e(t *testing.T) {
 	testConfig := defaultE2EConfig(t)
 

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -14,42 +14,56 @@ const (
 )
 
 func TestPickStringLast(t *testing.T) {
+	t.Parallel()
+
 	if v := PickString("", "", expectedValueString); v != expectedValueString {
 		t.Fatalf("expected %s, got %s", expectedValueString, v)
 	}
 }
 
 func TestPickStringNoValue(t *testing.T) {
+	t.Parallel()
+
 	if v := PickString(""); v != "" {
 		t.Fatalf("expected '%s', got '%s'", "", v)
 	}
 }
 
 func TestPickStringFirst(t *testing.T) {
+	t.Parallel()
+
 	if v := PickString(expectedValueString, "bar"); v != expectedValueString {
 		t.Fatalf("expected %s, got %s", expectedValueString, v)
 	}
 }
 
 func TestPickIntLast(t *testing.T) {
+	t.Parallel()
+
 	if v := PickInt(0, 0, expectedValueInt); v != expectedValueInt {
 		t.Fatalf("expected %d, got %d", expectedValueInt, v)
 	}
 }
 
 func TestPickIntNoValue(t *testing.T) {
+	t.Parallel()
+
 	if v := PickInt(0); v != 0 {
 		t.Fatalf("expected %d, got %d", 0, v)
 	}
 }
 
 func TestPickIntFirst(t *testing.T) {
+	t.Parallel()
+
 	if v := PickInt(expectedValueInt, 5); v != expectedValueInt {
 		t.Fatalf("expected %d, got %d", expectedValueInt, v)
 	}
 }
 
 func TestIndent(t *testing.T) {
+	t.Parallel()
+
 	expected := "   foo"
 	if a := Indent("foo", "   "); a != expected {
 		t.Fatalf("expected '%s', got '%s'", expected, a)
@@ -57,6 +71,8 @@ func TestIndent(t *testing.T) {
 }
 
 func TestIndentWithNewline(t *testing.T) {
+	t.Parallel()
+
 	expected := "  foo\n  bar\n"
 	if a := Indent("foo\nbar\n", "  "); a != expected {
 		t.Fatalf("expected '%s', got '%s'", expected, a)
@@ -64,6 +80,8 @@ func TestIndentWithNewline(t *testing.T) {
 }
 
 func TestIndentEmpty(t *testing.T) {
+	t.Parallel()
+
 	expected := ""
 	if a := Indent("", ""); a != expected {
 		t.Fatalf("expected '%s', got '%s'", expected, a)
@@ -71,6 +89,8 @@ func TestIndentEmpty(t *testing.T) {
 }
 
 func TestIndentEmptyText(t *testing.T) {
+	t.Parallel()
+
 	expected := ""
 	if a := Indent("", "  "); a != expected {
 		t.Fatalf("expected '%s', got '%s'", expected, a)
@@ -78,6 +98,8 @@ func TestIndentEmptyText(t *testing.T) {
 }
 
 func TestIndentEmptyIndent(t *testing.T) {
+	t.Parallel()
+
 	expected := "foo\nbar"
 	if a := Indent("foo\nbar", ""); a != expected {
 		t.Fatalf("expected '%s', got '%s'", expected, a)
@@ -85,6 +107,8 @@ func TestIndentEmptyIndent(t *testing.T) {
 }
 
 func TestJoinSorted(t *testing.T) {
+	t.Parallel()
+
 	expected := "baz/doh|foo/bar"
 
 	values := map[string]string{
@@ -98,6 +122,8 @@ func TestJoinSorted(t *testing.T) {
 }
 
 func TestPickStringSlice(t *testing.T) {
+	t.Parallel()
+
 	expected := []string{"foo"}
 	if v := PickStringSlice([]string{}, expected); !reflect.DeepEqual(v, expected) {
 		t.Fatalf("Expected %v, got %v", expected, v)
@@ -105,6 +131,8 @@ func TestPickStringSlice(t *testing.T) {
 }
 
 func TestPickStringMap(t *testing.T) {
+	t.Parallel()
+
 	expected := map[string]string{"foo": "bar"}
 	if v := PickStringMap(map[string]string{}, expected); !reflect.DeepEqual(v, expected) {
 		t.Fatalf("Expected %v, got %v", expected, v)
@@ -112,6 +140,8 @@ func TestPickStringMap(t *testing.T) {
 }
 
 func TestPickStringSliceEmpty(t *testing.T) {
+	t.Parallel()
+
 	expected := []string{}
 	if v := PickStringSlice([]string{}, expected); !reflect.DeepEqual(v, expected) {
 		t.Fatalf("Expected %v, got %v", expected, v)
@@ -119,6 +149,8 @@ func TestPickStringSliceEmpty(t *testing.T) {
 }
 
 func TestPickStringMapEmpty(t *testing.T) {
+	t.Parallel()
+
 	expected := map[string]string{}
 	if v := PickStringMap(map[string]string{}, expected); !reflect.DeepEqual(v, expected) {
 		t.Fatalf("Expected %v, got %v", expected, v)
@@ -126,6 +158,8 @@ func TestPickStringMapEmpty(t *testing.T) {
 }
 
 func TestKeysStringMap(t *testing.T) {
+	t.Parallel()
+
 	expected := []string{"baz", "foo"}
 	m := map[string]string{
 		"foo": "bar",

--- a/internal/util/validate_test.go
+++ b/internal/util/validate_test.go
@@ -6,6 +6,8 @@ import (
 )
 
 func TestValidateError(t *testing.T) {
+	t.Parallel()
+
 	err := func() error {
 		errors := ValidateError{
 			fmt.Errorf("first error"),

--- a/internal/utiltest/x509_test.go
+++ b/internal/utiltest/x509_test.go
@@ -6,6 +6,8 @@ import (
 
 // GenerateX509Certificate() tests.
 func TestGenerateX509Certificate(t *testing.T) {
+	t.Parallel()
+
 	if a := GenerateX509Certificate(t); a == "" {
 		t.Fatalf("Generating X509 certificate should not return empty string")
 	}
@@ -13,6 +15,8 @@ func TestGenerateX509Certificate(t *testing.T) {
 
 // GenerateRSAPrivateKey() tests.
 func TestGenerateRSAPrivateKey(t *testing.T) {
+	t.Parallel()
+
 	if a := GenerateRSAPrivateKey(t); a == "" {
 		t.Fatalf("Generating RSA private key should not return empty string")
 	}
@@ -20,6 +24,8 @@ func TestGenerateRSAPrivateKey(t *testing.T) {
 
 // GeneratePKI() tests.
 func TestGeneratePKI(t *testing.T) {
+	t.Parallel()
+
 	p := GeneratePKI(t)
 
 	if p.Certificate == "" {

--- a/pkg/apiloadbalancer/api-loadbalancer_test.go
+++ b/pkg/apiloadbalancer/api-loadbalancer_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestToHostConfiguredContainer(t *testing.T) {
+	t.Parallel()
+
 	kk := &APILoadBalancer{
 		Host: host.Host{
 			DirectConfig: &direct.Config{},
@@ -37,6 +39,8 @@ func TestToHostConfiguredContainer(t *testing.T) {
 
 // Validate() tests.
 func TestValidateRequireServers(t *testing.T) {
+	t.Parallel()
+
 	kk := &APILoadBalancer{
 		BindAddress: "0.0.0.0:6434",
 		Host: host.Host{
@@ -50,6 +54,8 @@ func TestValidateRequireServers(t *testing.T) {
 }
 
 func TestValidateRequireBindAddress(t *testing.T) {
+	t.Parallel()
+
 	kk := &APILoadBalancer{
 		Servers: []string{"foo"},
 		Host: host.Host{
@@ -64,6 +70,8 @@ func TestValidateRequireBindAddress(t *testing.T) {
 
 // New() tests.
 func TestNewValidate(t *testing.T) {
+	t.Parallel()
+
 	kk := &APILoadBalancer{
 		Host: host.Host{
 			DirectConfig: &direct.Config{},

--- a/pkg/apiloadbalancer/api-loadbalancers_integration_test.go
+++ b/pkg/apiloadbalancer/api-loadbalancers_integration_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestDeploy(t *testing.T) {
+	t.Parallel()
+
 	key, err := ioutil.ReadFile("/home/core/.ssh/id_rsa")
 	if err != nil {
 		t.Fatalf("reading SSH private key shouldn't fail, got: %v", err)

--- a/pkg/apiloadbalancer/api-loadbalancers_test.go
+++ b/pkg/apiloadbalancer/api-loadbalancers_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestPoolNoInstancesDefined(t *testing.T) {
+	t.Parallel()
+
 	a := &APILoadBalancers{}
 
 	if err := a.Validate(); err == nil {
@@ -41,6 +43,8 @@ servers:
 
 // New() tests.
 func TestLoadBalancersNewValidate(t *testing.T) {
+	t.Parallel()
+
 	y := `
 ssh:
   address: localhost
@@ -60,11 +64,14 @@ apiLoadBalancers:
 
 // FromYaml() tests.
 func TestLoadBalancersFromYaml(t *testing.T) {
+	t.Parallel()
 	GetLoadBalancers(t)
 }
 
 // StateToYaml() tests.
 func TestLoadBalancersStateToYAML(t *testing.T) {
+	t.Parallel()
+
 	p := GetLoadBalancers(t)
 
 	if _, err := p.StateToYaml(); err != nil {
@@ -74,6 +81,8 @@ func TestLoadBalancersStateToYAML(t *testing.T) {
 
 // CheckCurrentState() tests.
 func TestLoadBalancersCheckCurrentState(t *testing.T) {
+	t.Parallel()
+
 	p := GetLoadBalancers(t)
 
 	if err := p.CheckCurrentState(); err != nil {
@@ -83,6 +92,8 @@ func TestLoadBalancersCheckCurrentState(t *testing.T) {
 
 // Deploy() tests.
 func TestLoadBalancersDeploy(t *testing.T) {
+	t.Parallel()
+
 	p := GetLoadBalancers(t)
 
 	if err := p.Deploy(); err == nil {
@@ -92,6 +103,8 @@ func TestLoadBalancersDeploy(t *testing.T) {
 
 // Containers() tests.
 func TestLoadBalancersContainers(t *testing.T) {
+	t.Parallel()
+
 	p := GetLoadBalancers(t)
 
 	if c := p.Containers(); c == nil {

--- a/pkg/container/container_integration_test.go
+++ b/pkg/container/container_integration_test.go
@@ -15,6 +15,8 @@ import (
 
 // Create() tests.
 func TestDockerCreateNonExistingImage(t *testing.T) {
+	t.Parallel()
+
 	cc := &Container{
 		Runtime: RuntimeConfig{
 			Docker: &docker.Config{},
@@ -36,6 +38,8 @@ func TestDockerCreateNonExistingImage(t *testing.T) {
 }
 
 func TestDockerCreate(t *testing.T) {
+	t.Parallel()
+
 	cc := &Container{
 		Runtime: RuntimeConfig{
 			Docker: &docker.Config{},
@@ -58,6 +62,8 @@ func TestDockerCreate(t *testing.T) {
 
 // Status() tests.
 func TestDockerStatus(t *testing.T) {
+	t.Parallel()
+
 	cc := &Container{
 		Runtime: RuntimeConfig{
 			Docker: &docker.Config{},
@@ -84,6 +90,8 @@ func TestDockerStatus(t *testing.T) {
 }
 
 func TestDockerStatusNonExistingContainer(t *testing.T) {
+	t.Parallel()
+
 	cc := &Container{
 		Runtime: RuntimeConfig{
 			Docker: &docker.Config{},
@@ -118,6 +126,8 @@ func TestDockerStatusNonExistingContainer(t *testing.T) {
 
 // Start() tests.
 func TestDockerStart(t *testing.T) {
+	t.Parallel()
+
 	cc := &Container{
 		Runtime: RuntimeConfig{
 			Docker: &docker.Config{},
@@ -145,6 +155,8 @@ func TestDockerStart(t *testing.T) {
 
 // Stop() tests.
 func TestDockerStop(t *testing.T) {
+	t.Parallel()
+
 	cc := &Container{
 		Runtime: RuntimeConfig{
 			Docker: &docker.Config{},
@@ -176,6 +188,8 @@ func TestDockerStop(t *testing.T) {
 
 // Delete() tests.
 func TestDockerDelete(t *testing.T) {
+	t.Parallel()
+
 	cc := &Container{
 		Runtime: RuntimeConfig{
 			Docker: &docker.Config{},

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -13,12 +13,16 @@ import (
 
 // New() tests.
 func TestNewEmptyConfiguration(t *testing.T) {
+	t.Parallel()
+
 	if _, err := (&Container{}).New(); err == nil {
 		t.Errorf("Creating container with wrong configuration should fail")
 	}
 }
 
 func TestNewGoodConfiguration(t *testing.T) {
+	t.Parallel()
+
 	c := &Container{
 		Runtime: RuntimeConfig{
 			Docker: &docker.Config{},
@@ -35,6 +39,8 @@ func TestNewGoodConfiguration(t *testing.T) {
 
 // Validate() tests.
 func TestValidateNoName(t *testing.T) {
+	t.Parallel()
+
 	c := &Container{
 		Config: types.ContainerConfig{},
 	}
@@ -44,6 +50,8 @@ func TestValidateNoName(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
+	t.Parallel()
+
 	c := &Container{
 		Runtime: RuntimeConfig{
 			Docker: &docker.Config{},
@@ -59,6 +67,8 @@ func TestValidate(t *testing.T) {
 }
 
 func TestValidateUnsupportedRuntime(t *testing.T) {
+	t.Parallel()
+
 	c := &Container{
 		Config: types.ContainerConfig{
 			Name:  "foo",
@@ -71,6 +81,8 @@ func TestValidateUnsupportedRuntime(t *testing.T) {
 }
 
 func TestValidateRequireImage(t *testing.T) {
+	t.Parallel()
+
 	c := &Container{
 		Config: types.ContainerConfig{
 			Name: "foo",
@@ -83,6 +95,8 @@ func TestValidateRequireImage(t *testing.T) {
 
 // selectRuntime() tests.
 func TestSelectDockerRuntime(t *testing.T) {
+	t.Parallel()
+
 	c := &container{
 		base: base{
 			runtimeConfig: &docker.Config{},
@@ -100,6 +114,8 @@ func TestSelectDockerRuntime(t *testing.T) {
 
 // FromStatus() tests.
 func TestFromStatusValid(t *testing.T) {
+	t.Parallel()
+
 	c := &container{
 		base: base{
 			status: types.ContainerStatus{
@@ -113,6 +129,8 @@ func TestFromStatusValid(t *testing.T) {
 }
 
 func TestFromStatusNoID(t *testing.T) {
+	t.Parallel()
+
 	c := &container{
 		base: base{
 			status: types.ContainerStatus{},
@@ -125,6 +143,8 @@ func TestFromStatusNoID(t *testing.T) {
 
 // Status() tests.
 func TestStatus(t *testing.T) {
+	t.Parallel()
+
 	c := &containerInstance{
 		base: base{
 			runtime: runtime.Fake{
@@ -142,6 +162,8 @@ func TestStatus(t *testing.T) {
 
 // UpdateStatus() tests.
 func TestContainerUpdateStatusEmptyStatus(t *testing.T) {
+	t.Parallel()
+
 	c := &container{}
 
 	if err := c.UpdateStatus(); err == nil {
@@ -150,6 +172,8 @@ func TestContainerUpdateStatusEmptyStatus(t *testing.T) {
 }
 
 func TestContainerUpdateStatusFail(t *testing.T) {
+	t.Parallel()
+
 	c := &container{
 		base: base{
 			runtime: runtime.Fake{
@@ -169,6 +193,8 @@ func TestContainerUpdateStatusFail(t *testing.T) {
 }
 
 func TestContainerUpdateStatus(t *testing.T) {
+	t.Parallel()
+
 	ns := types.ContainerStatus{
 		ID:     "foo",
 		Status: "running",
@@ -199,6 +225,8 @@ func TestContainerUpdateStatus(t *testing.T) {
 
 // Start() tests.
 func TestContainerStartBadState(t *testing.T) {
+	t.Parallel()
+
 	c := &container{
 		base: base{
 			status: types.ContainerStatus{},
@@ -211,6 +239,8 @@ func TestContainerStartBadState(t *testing.T) {
 }
 
 func TestContainerStartRuntimeError(t *testing.T) {
+	t.Parallel()
+
 	c := &container{
 		base: base{
 			runtime: runtime.Fake{
@@ -231,6 +261,8 @@ func TestContainerStartRuntimeError(t *testing.T) {
 }
 
 func TestContainerStart(t *testing.T) {
+	t.Parallel()
+
 	ns := types.ContainerStatus{
 		ID:     "foo",
 		Status: "running",
@@ -264,6 +296,8 @@ func TestContainerStart(t *testing.T) {
 
 // Stop() tests.
 func TestContainerStopBadState(t *testing.T) {
+	t.Parallel()
+
 	c := &container{
 		base: base{
 			status: types.ContainerStatus{},
@@ -276,6 +310,8 @@ func TestContainerStopBadState(t *testing.T) {
 }
 
 func TestContainerStopRuntimeError(t *testing.T) {
+	t.Parallel()
+
 	c := &container{
 		base: base{
 			runtime: runtime.Fake{
@@ -296,6 +332,8 @@ func TestContainerStopRuntimeError(t *testing.T) {
 }
 
 func TestContainerStop(t *testing.T) {
+	t.Parallel()
+
 	ns := types.ContainerStatus{
 		ID:     "foo",
 		Status: "stopped",
@@ -329,6 +367,8 @@ func TestContainerStop(t *testing.T) {
 
 // Delete() tests.
 func TestContainerDeleteBadState(t *testing.T) {
+	t.Parallel()
+
 	c := &container{
 		base: base{
 			status: types.ContainerStatus{},
@@ -341,6 +381,8 @@ func TestContainerDeleteBadState(t *testing.T) {
 }
 
 func TestContainerDeleteRuntimeError(t *testing.T) {
+	t.Parallel()
+
 	c := &container{
 		base: base{
 			runtime: runtime.Fake{
@@ -361,6 +403,8 @@ func TestContainerDeleteRuntimeError(t *testing.T) {
 }
 
 func TestContainerDelete(t *testing.T) {
+	t.Parallel()
+
 	c := &container{
 		base: base{
 			runtime: runtime.Fake{
@@ -386,6 +430,8 @@ func TestContainerDelete(t *testing.T) {
 
 // SetStatus() tests.
 func TestContainerSetStatus(t *testing.T) {
+	t.Parallel()
+
 	c := &container{
 		base: base{
 			status: types.ContainerStatus{

--- a/pkg/container/containers_test.go
+++ b/pkg/container/containers_test.go
@@ -22,6 +22,8 @@ const (
 
 // New() tests.
 func TestContainersNew(t *testing.T) {
+	t.Parallel()
+
 	GetContainers(t)
 }
 
@@ -55,6 +57,8 @@ func GetContainers(t *testing.T) ContainersInterface {
 
 // Containers() tests.
 func TestContainersContainers(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{}
 
 	if !reflect.DeepEqual(c, c.Containers()) {
@@ -64,6 +68,8 @@ func TestContainersContainers(t *testing.T) {
 
 // CheckCurrentState() tests.
 func TestContainersCheckCurrentStateNew(t *testing.T) {
+	t.Parallel()
+
 	c := GetContainers(t)
 
 	if err := c.CheckCurrentState(); err != nil {
@@ -73,6 +79,8 @@ func TestContainersCheckCurrentStateNew(t *testing.T) {
 
 // CurrentStateToYaml() tests.
 func TestContainersCurrentStateToYAML(t *testing.T) {
+	t.Parallel()
+
 	c := GetContainers(t)
 
 	_, err := c.StateToYaml()
@@ -83,6 +91,8 @@ func TestContainersCurrentStateToYAML(t *testing.T) {
 
 // ToExported() tests.
 func TestContainersToExported(t *testing.T) {
+	t.Parallel()
+
 	c := GetContainers(t)
 
 	c.ToExported()
@@ -90,12 +100,16 @@ func TestContainersToExported(t *testing.T) {
 
 // FromYaml() tests.
 func TestContainersFromYamlBad(t *testing.T) {
+	t.Parallel()
+
 	if _, err := FromYaml([]byte{}); err == nil {
 		t.Fatalf("Creating containers from empty YAML should fail")
 	}
 }
 
 func TestContainersFromYaml(t *testing.T) {
+	t.Parallel()
+
 	y := `
 desiredState:
  foo:
@@ -116,6 +130,8 @@ desiredState:
 
 // filesToUpdate() tests.
 func TestFilesToUpdateEmpty(t *testing.T) {
+	t.Parallel()
+
 	expected := []string{foo}
 
 	d := hostConfiguredContainer{
@@ -131,6 +147,8 @@ func TestFilesToUpdateEmpty(t *testing.T) {
 
 // Validate() tests.
 func TestValidateEmpty(t *testing.T) {
+	t.Parallel()
+
 	cc := &Containers{}
 
 	if err := cc.Validate(); err == nil {
@@ -139,6 +157,8 @@ func TestValidateEmpty(t *testing.T) {
 }
 
 func TestValidateNil(t *testing.T) {
+	t.Parallel()
+
 	var cc Containers
 
 	if err := cc.Validate(); err == nil {
@@ -147,6 +167,8 @@ func TestValidateNil(t *testing.T) {
 }
 
 func TestValidateNoContainers(t *testing.T) {
+	t.Parallel()
+
 	cc := &Containers{
 		DesiredState:  ContainersState{},
 		PreviousState: ContainersState{},
@@ -158,6 +180,8 @@ func TestValidateNoContainers(t *testing.T) {
 }
 
 func TestValidateBadDesiredContainers(t *testing.T) {
+	t.Parallel()
+
 	cc := &Containers{
 		DesiredState: ContainersState{
 			foo: &HostConfiguredContainer{},
@@ -171,6 +195,8 @@ func TestValidateBadDesiredContainers(t *testing.T) {
 }
 
 func TestValidateBadCurrentContainers(t *testing.T) {
+	t.Parallel()
+
 	cc := &Containers{
 		DesiredState: ContainersState{},
 		PreviousState: ContainersState{
@@ -185,6 +211,8 @@ func TestValidateBadCurrentContainers(t *testing.T) {
 
 // isUpdatable() tests.
 func TestIsUpdatableWithoutCurrentState(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		desiredState: containersState{
 			foo: &hostConfiguredContainer{},
@@ -197,6 +225,8 @@ func TestIsUpdatableWithoutCurrentState(t *testing.T) {
 }
 
 func TestIsUpdatableToBeDeleted(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		currentState: containersState{
 			foo: &hostConfiguredContainer{},
@@ -209,6 +239,8 @@ func TestIsUpdatableToBeDeleted(t *testing.T) {
 }
 
 func TestIsUpdatable(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		desiredState: containersState{
 			foo: &hostConfiguredContainer{},
@@ -225,6 +257,8 @@ func TestIsUpdatable(t *testing.T) {
 
 // diffHost() tests.
 func TestDiffHostNotUpdatable(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		currentState: containersState{
 			foo: &hostConfiguredContainer{},
@@ -237,6 +271,8 @@ func TestDiffHostNotUpdatable(t *testing.T) {
 }
 
 func TestDiffHostNoDiff(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		desiredState: containersState{
 			foo: &hostConfiguredContainer{
@@ -261,6 +297,8 @@ func TestDiffHostNoDiff(t *testing.T) {
 }
 
 func TestDiffHost(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		desiredState: containersState{
 			foo: &hostConfiguredContainer{
@@ -288,6 +326,8 @@ func TestDiffHost(t *testing.T) {
 
 // diffContainer() tests.
 func TestDiffContainerNotUpdatable(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		currentState: containersState{
 			foo: &hostConfiguredContainer{},
@@ -300,6 +340,8 @@ func TestDiffContainerNotUpdatable(t *testing.T) {
 }
 
 func TestDiffContainerNoDiff(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		desiredState: containersState{
 			foo: &hostConfiguredContainer{
@@ -332,6 +374,8 @@ func TestDiffContainerNoDiff(t *testing.T) {
 }
 
 func TestDiffContainer(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		desiredState: containersState{
 			foo: &hostConfiguredContainer{
@@ -366,6 +410,8 @@ func TestDiffContainer(t *testing.T) {
 }
 
 func TestDiffContainerRuntimeConfig(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		desiredState: containersState{
 			foo: &hostConfiguredContainer{
@@ -403,6 +449,8 @@ func TestDiffContainerRuntimeConfig(t *testing.T) {
 
 // ensureRunning() tests.
 func TestEnsureRunningNonExistent(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		currentState: containersState{},
 	}
@@ -413,6 +461,8 @@ func TestEnsureRunningNonExistent(t *testing.T) {
 }
 
 func TestEnsureRunning(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		desiredState: containersState{
 			foo: &hostConfiguredContainer{
@@ -445,6 +495,8 @@ func TestEnsureRunning(t *testing.T) {
 
 // ensureExists() tests.
 func TestEnsureExistsAlreadyExists(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		currentState: containersState{
 			foo: &hostConfiguredContainer{
@@ -466,6 +518,8 @@ func TestEnsureExistsAlreadyExists(t *testing.T) {
 }
 
 func TestEnsureExistsFailCreate(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		currentState: containersState{},
 		desiredState: containersState{
@@ -499,6 +553,8 @@ func TestEnsureExistsFailCreate(t *testing.T) {
 }
 
 func TestEnsureExistsFailStart(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		currentState: containersState{},
 		desiredState: containersState{
@@ -544,6 +600,8 @@ func TestEnsureExistsFailStart(t *testing.T) {
 }
 
 func TestEnsureExist(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		currentState: containersState{},
 		desiredState: containersState{
@@ -590,6 +648,8 @@ func TestEnsureExist(t *testing.T) {
 
 // ensureHost() tests.
 func TestEnsureHostNoDiff(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		desiredState: containersState{
 			foo: &hostConfiguredContainer{
@@ -612,7 +672,10 @@ func TestEnsureHostNoDiff(t *testing.T) {
 	}
 }
 
-func TestEnsureHostFailStart(t *testing.T) { //nolint:funlen
+//nolint:funlen
+func TestEnsureHostFailStart(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		desiredState: containersState{
 			foo: &hostConfiguredContainer{
@@ -686,7 +749,10 @@ func TestEnsureHostFailStart(t *testing.T) { //nolint:funlen
 	}
 }
 
-func TestEnsureHost(t *testing.T) { //nolint:funlen
+//nolint:funlen
+func TestEnsureHost(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		desiredState: containersState{
 			foo: &hostConfiguredContainer{
@@ -762,6 +828,8 @@ func TestEnsureHost(t *testing.T) { //nolint:funlen
 
 // ensureContainer() tests.
 func TestEnsureContainerNoDiff(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		desiredState: containersState{
 			foo: &hostConfiguredContainer{
@@ -788,7 +856,10 @@ func TestEnsureContainerNoDiff(t *testing.T) {
 	}
 }
 
-func TestEnsureContainerFailStart(t *testing.T) { //nolint:funlen
+//nolint:funlen
+func TestEnsureContainerFailStart(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		desiredState: containersState{
 			foo: &hostConfiguredContainer{
@@ -866,7 +937,10 @@ func TestEnsureContainerFailStart(t *testing.T) { //nolint:funlen
 	}
 }
 
-func TestEnsureContainer(t *testing.T) { //nolint:funlen
+//nolint:funlen
+func TestEnsureContainer(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		desiredState: containersState{
 			foo: &hostConfiguredContainer{
@@ -946,6 +1020,8 @@ func TestEnsureContainer(t *testing.T) { //nolint:funlen
 
 // recreate() tests.
 func TestRecreateNonExistent(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{}
 	if err := c.recreate(foo); err == nil {
 		t.Fatalf("Recreating on empty containers should fail")
@@ -954,6 +1030,8 @@ func TestRecreateNonExistent(t *testing.T) {
 
 // Deploy() tests.
 func TestDeployNoCurrentState(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{}
 	if err := c.Deploy(); err == nil {
 		t.Fatalf("Execute without current state should fail")
@@ -962,6 +1040,8 @@ func TestDeployNoCurrentState(t *testing.T) {
 
 // hasUpdates() tests.
 func TestHasUpdatesHost(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		desiredState: containersState{
 			foo: &hostConfiguredContainer{
@@ -998,6 +1078,8 @@ func TestHasUpdatesHost(t *testing.T) {
 }
 
 func TestHasUpdatesConfig(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		desiredState: containersState{
 			foo: &hostConfiguredContainer{
@@ -1033,6 +1115,8 @@ func TestHasUpdatesConfig(t *testing.T) {
 }
 
 func TestHasUpdatesContainer(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		desiredState: containersState{
 			foo: &hostConfiguredContainer{
@@ -1067,6 +1151,8 @@ func TestHasUpdatesContainer(t *testing.T) {
 }
 
 func TestHasUpdatesNoUpdates(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		desiredState: containersState{
 			foo: &hostConfiguredContainer{
@@ -1100,6 +1186,8 @@ func TestHasUpdatesNoUpdates(t *testing.T) {
 
 // ensureConfigured() tests.
 func TestEnsureConfiguredDisposable(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		desiredState: containersState{},
 		currentState: containersState{
@@ -1115,6 +1203,8 @@ func TestEnsureConfiguredDisposable(t *testing.T) {
 }
 
 func TestEnsureConfiguredNoUpdates(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		desiredState: containersState{
 			foo: &hostConfiguredContainer{
@@ -1133,7 +1223,10 @@ func TestEnsureConfiguredNoUpdates(t *testing.T) {
 	}
 }
 
-func TestEnsureConfigured(t *testing.T) { //nolint:funlen
+//nolint:funlen
+func TestEnsureConfigured(t *testing.T) {
+	t.Parallel()
+
 	called := false
 
 	f := foo
@@ -1220,7 +1313,10 @@ func TestEnsureConfigured(t *testing.T) { //nolint:funlen
 	}
 }
 
+//nolint:funlen
 func TestEnsureConfiguredFreshState(t *testing.T) {
+	t.Parallel()
+
 	called := false
 
 	f := foo
@@ -1284,6 +1380,8 @@ func TestEnsureConfiguredFreshState(t *testing.T) {
 }
 
 func TestEnsureConfiguredNoStateUpdateOnFail(t *testing.T) {
+	t.Parallel()
+
 	f := foo
 
 	cf := map[string]string{
@@ -1333,6 +1431,8 @@ func TestEnsureConfiguredNoStateUpdateOnFail(t *testing.T) {
 
 // selectRuntime() tests.
 func TestSelectRuntime(t *testing.T) {
+	t.Parallel()
+
 	c := &container{
 		base: base{
 			runtimeConfig: &docker.Config{},
@@ -1350,6 +1450,8 @@ func TestSelectRuntime(t *testing.T) {
 
 // DesiredState() tests.
 func TestContainersDesiredStateEmpty(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{}
 
 	e := ContainersState{}
@@ -1360,6 +1462,8 @@ func TestContainersDesiredStateEmpty(t *testing.T) {
 }
 
 func TestContainersDesiredStateOldID(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		desiredState: containersState{
 			foo: &hostConfiguredContainer{
@@ -1410,6 +1514,8 @@ func TestContainersDesiredStateOldID(t *testing.T) {
 }
 
 func TestContainersDesiredStateStatusRunning(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		desiredState: containersState{
 			foo: &hostConfiguredContainer{
@@ -1459,7 +1565,11 @@ func TestContainersDesiredStateStatusRunning(t *testing.T) {
 }
 
 // updateExistingContainers() tests.
-func TestUpdateExistingContainersRemoveAllOld(t *testing.T) { //nolint:funlen
+//
+//nolint:funlen
+func TestUpdateExistingContainersRemoveAllOld(t *testing.T) {
+	t.Parallel()
+
 	c := &containers{
 		desiredState: containersState{},
 		currentState: containersState{
@@ -1537,6 +1647,8 @@ func TestUpdateExistingContainersRemoveAllOld(t *testing.T) { //nolint:funlen
 
 // ensureCurrentContainer() tests.
 func TestEnsureCurrentContainer(t *testing.T) {
+	t.Parallel()
+
 	hcc := hostConfiguredContainer{
 		hooks: &Hooks{},
 		host: host.Host{
@@ -1575,6 +1687,8 @@ func TestEnsureCurrentContainer(t *testing.T) {
 }
 
 func TestEnsureCurrentContainerNonExisting(t *testing.T) {
+	t.Parallel()
+
 	hcc := hostConfiguredContainer{
 		hooks: &Hooks{},
 		host: host.Host{

--- a/pkg/container/containersstate_test.go
+++ b/pkg/container/containersstate_test.go
@@ -15,6 +15,8 @@ import (
 
 // ToExported() tests.
 func TestToExported(t *testing.T) {
+	t.Parallel()
+
 	c := containersState{
 		"foo": &hostConfiguredContainer{
 			container: &container{
@@ -49,6 +51,8 @@ func TestToExported(t *testing.T) {
 
 // CheckState() tests.
 func TestContainersStateCheckStateFailStatus(t *testing.T) {
+	t.Parallel()
+
 	c := containersState{
 		"foo": &hostConfiguredContainer{
 			host: host.Host{
@@ -85,6 +89,8 @@ func TestContainersStateCheckStateFailStatus(t *testing.T) {
 }
 
 func TestContainersStateCheckStateGone(t *testing.T) {
+	t.Parallel()
+
 	c := containersState{
 		"foo": &hostConfiguredContainer{
 			host: host.Host{
@@ -123,7 +129,11 @@ func TestContainersStateCheckStateGone(t *testing.T) {
 }
 
 // RemoveContainer() tests.
-func TestRemoveContainerDontStopStopped(t *testing.T) { //nolint:dupl
+//
+//nolint:dupl
+func TestRemoveContainerDontStopStopped(t *testing.T) {
+	t.Parallel()
+
 	c := containersState{
 		"foo": &hostConfiguredContainer{
 			hooks: &Hooks{},
@@ -163,6 +173,8 @@ func TestRemoveContainerDontStopStopped(t *testing.T) { //nolint:dupl
 }
 
 func TestRemoveContainerDontRemoveMissing(t *testing.T) {
+	t.Parallel()
+
 	c := containersState{
 		"foo": &hostConfiguredContainer{
 			hooks: &Hooks{},
@@ -195,7 +207,10 @@ func TestRemoveContainerDontRemoveMissing(t *testing.T) {
 	}
 }
 
-func TestRemoveContainerPropagateStopError(t *testing.T) { //nolint:dupl
+//nolint:dupl
+func TestRemoveContainerPropagateStopError(t *testing.T) {
+	t.Parallel()
+
 	c := containersState{
 		"foo": &hostConfiguredContainer{
 			hooks: &Hooks{},
@@ -235,6 +250,8 @@ func TestRemoveContainerPropagateStopError(t *testing.T) { //nolint:dupl
 }
 
 func TestRemoveContainerPropagateDeleteError(t *testing.T) {
+	t.Parallel()
+
 	c := containersState{
 		"foo": &hostConfiguredContainer{
 			hooks: &Hooks{},
@@ -275,6 +292,8 @@ func TestRemoveContainerPropagateDeleteError(t *testing.T) {
 
 // createAndStart() tests.
 func TestCreateAndStartFailOnMissingContainer(t *testing.T) {
+	t.Parallel()
+
 	c := containersState{}
 
 	if err := c.CreateAndStart("foo"); err == nil {

--- a/pkg/container/hostconfiguredcontainer_integration_test.go
+++ b/pkg/container/hostconfiguredcontainer_integration_test.go
@@ -20,7 +20,11 @@ const (
 )
 
 // Create() tests.
-func TestHostConfiguredContainerDeployConfigFile(t *testing.T) { //nolint:funlen
+//
+//nolint:funlen
+func TestHostConfiguredContainerDeployConfigFile(t *testing.T) {
+	t.Parallel()
+
 	p := "/tmp/foo"
 	f := path.Join(p, randomContainerName())
 
@@ -92,6 +96,8 @@ func TestHostConfiguredContainerDeployConfigFile(t *testing.T) { //nolint:funlen
 }
 
 func TestHostConfiguredContainerPostStartHook(t *testing.T) {
+	t.Parallel()
+
 	hookCalled := false
 
 	f := Hook(func() error {

--- a/pkg/container/hostconfiguredcontainer_test.go
+++ b/pkg/container/hostconfiguredcontainer_test.go
@@ -17,6 +17,8 @@ import (
 
 // withHook() tests.
 func TestWithHook(t *testing.T) {
+	t.Parallel()
+
 	action := false
 
 	if err := withHook(nil, func() error {
@@ -33,6 +35,8 @@ func TestWithHook(t *testing.T) {
 }
 
 func TestWithPreHook(t *testing.T) {
+	t.Parallel()
+
 	pre := false
 
 	f := Hook(func() error {
@@ -53,6 +57,8 @@ func TestWithPreHook(t *testing.T) {
 }
 
 func TestWithPostHook(t *testing.T) {
+	t.Parallel()
+
 	post := false
 
 	f := Hook(func() error {
@@ -73,6 +79,8 @@ func TestWithPostHook(t *testing.T) {
 }
 
 func TestConnectAndForward(t *testing.T) {
+	t.Parallel()
+
 	addr := &net.UnixAddr{
 		Name: "@foo",
 		Net:  "unix",
@@ -105,6 +113,8 @@ func TestConnectAndForward(t *testing.T) {
 
 // Status() tests.
 func TestHostConfiguredContainerStatusNotExist(t *testing.T) {
+	t.Parallel()
+
 	h := &hostConfiguredContainer{
 		container: &container{},
 	}
@@ -115,6 +125,8 @@ func TestHostConfiguredContainerStatusNotExist(t *testing.T) {
 }
 
 func TestHostConfiguredContainerStatus(t *testing.T) {
+	t.Parallel()
+
 	h := &hostConfiguredContainer{
 		host: host.Host{
 			DirectConfig: &direct.Config{},
@@ -142,6 +154,8 @@ func TestHostConfiguredContainerStatus(t *testing.T) {
 
 // createConfigurationContainer() tests.
 func TestHostConfiguredContainerCreateConfigurationContainer(t *testing.T) {
+	t.Parallel()
+
 	h := &hostConfiguredContainer{
 		container: &container{
 			base: base{
@@ -161,6 +175,8 @@ func TestHostConfiguredContainerCreateConfigurationContainer(t *testing.T) {
 
 // removeConfigurationContainer() tests.
 func TestHostConfiguredContainerRemoveConfigurationContainer(t *testing.T) {
+	t.Parallel()
+
 	deleted := false
 	i := foo
 
@@ -200,6 +216,8 @@ func TestHostConfiguredContainerRemoveConfigurationContainer(t *testing.T) {
 }
 
 func TestHostConfiguredContainerRemoveConfigurationContainerFailStatus(t *testing.T) {
+	t.Parallel()
+
 	h := &hostConfiguredContainer{
 		configContainer: &containerInstance{
 			base: base{
@@ -219,6 +237,8 @@ func TestHostConfiguredContainerRemoveConfigurationContainerFailStatus(t *testin
 
 // statMounts() tests.
 func TestStatMountsNoMounts(t *testing.T) {
+	t.Parallel()
+
 	h := &hostConfiguredContainer{
 		container: &container{},
 	}
@@ -229,6 +249,8 @@ func TestStatMountsNoMounts(t *testing.T) {
 }
 
 func TestStatMountsRuntimeError(t *testing.T) {
+	t.Parallel()
+
 	h := &hostConfiguredContainer{
 		configContainer: &containerInstance{
 			base: base{
@@ -259,6 +281,8 @@ func TestStatMountsRuntimeError(t *testing.T) {
 }
 
 func TestStatMounts(t *testing.T) {
+	t.Parallel()
+
 	m := map[string]os.FileMode{
 		"/etc": os.ModeDir,
 	}
@@ -299,6 +323,8 @@ func TestStatMounts(t *testing.T) {
 
 // createMissingMounts() tests.
 func TestCreateMissingMountpointsStatFail(t *testing.T) {
+	t.Parallel()
+
 	h := &hostConfiguredContainer{
 		configContainer: &containerInstance{
 			base: base{
@@ -329,6 +355,8 @@ func TestCreateMissingMountpointsStatFail(t *testing.T) {
 }
 
 func TestCreateMissingMountpointsMountpointFile(t *testing.T) {
+	t.Parallel()
+
 	h := &hostConfiguredContainer{
 		configContainer: &containerInstance{
 			base: base{
@@ -361,6 +389,8 @@ func TestCreateMissingMountpointsMountpointFile(t *testing.T) {
 }
 
 func TestCreateMissingMountpointsNoMountsToCreate(t *testing.T) {
+	t.Parallel()
+
 	h := &hostConfiguredContainer{
 		configContainer: &containerInstance{
 			base: base{
@@ -393,6 +423,8 @@ func TestCreateMissingMountpointsNoMountsToCreate(t *testing.T) {
 }
 
 func TestCreateMissingMountpointsCopyFail(t *testing.T) {
+	t.Parallel()
+
 	h := &hostConfiguredContainer{
 		configContainer: &containerInstance{
 			base: base{
@@ -426,6 +458,8 @@ func TestCreateMissingMountpointsCopyFail(t *testing.T) {
 }
 
 func TestCreateMissingMountpoints(t *testing.T) {
+	t.Parallel()
+
 	called := false
 
 	f := []*types.File{
@@ -480,6 +514,8 @@ func TestCreateMissingMountpoints(t *testing.T) {
 
 // dirMounts() tests.
 func TestDirMounts(t *testing.T) {
+	t.Parallel()
+
 	m := types.Mount{
 		Source: "/etc/",
 		Target: "/etc",
@@ -508,6 +544,8 @@ func TestDirMounts(t *testing.T) {
 
 // withForwardedRuntime() tests.
 func TestWithForwardedRuntimeFailForward(t *testing.T) {
+	t.Parallel()
+
 	h := &hostConfiguredContainer{
 		container: &container{
 			base: base{
@@ -526,6 +564,8 @@ func TestWithForwardedRuntimeFailForward(t *testing.T) {
 }
 
 func TestWithForwardedRuntimeFailRuntime(t *testing.T) {
+	t.Parallel()
+
 	h := &hostConfiguredContainer{
 		host: host.Host{
 			DirectConfig: &direct.Config{},
@@ -545,6 +585,8 @@ func TestWithForwardedRuntimeFailRuntime(t *testing.T) {
 }
 
 func TestWithForwardedRuntime(t *testing.T) {
+	t.Parallel()
+
 	r := &runtime.Fake{}
 
 	h := &hostConfiguredContainer{
@@ -570,6 +612,8 @@ func TestWithForwardedRuntime(t *testing.T) {
 
 // Create() tests.
 func TestHostConfiguredContainerCreateFailMountpoints(t *testing.T) {
+	t.Parallel()
+
 	h := &hostConfiguredContainer{
 		host: host.Host{
 			DirectConfig: &direct.Config{},
@@ -610,6 +654,8 @@ func TestHostConfiguredContainerCreateFailMountpoints(t *testing.T) {
 }
 
 func TestHostConfiguredContainerCreateFail(t *testing.T) {
+	t.Parallel()
+
 	fail := false
 
 	h := &hostConfiguredContainer{
@@ -660,6 +706,8 @@ func TestHostConfiguredContainerCreateFail(t *testing.T) {
 }
 
 func TestHostConfiguredContainerCreateFailStatus(t *testing.T) {
+	t.Parallel()
+
 	fail := false
 
 	h := &hostConfiguredContainer{
@@ -710,6 +758,8 @@ func TestHostConfiguredContainerCreateFailStatus(t *testing.T) {
 }
 
 func TestHostConfiguredContainerCreate(t *testing.T) {
+	t.Parallel()
+
 	h := &hostConfiguredContainer{
 		host: host.Host{
 			DirectConfig: &direct.Config{},
@@ -759,6 +809,8 @@ func TestHostConfiguredContainerCreate(t *testing.T) {
 
 // updateConfigurationStatus() tests.
 func TestHostConfiguredContainerUpdateConfigurationStatusNoAction(t *testing.T) {
+	t.Parallel()
+
 	h := &hostConfiguredContainer{
 		host: host.Host{
 			DirectConfig: &direct.Config{},
@@ -785,6 +837,8 @@ func TestHostConfiguredContainerUpdateConfigurationStatusNoAction(t *testing.T) 
 }
 
 func TestHostConfiguredContainerUpdateConfigurationStatusFileMissing(t *testing.T) {
+	t.Parallel()
+
 	h := &hostConfiguredContainer{
 		configFiles: map[string]string{
 			"/foo": "bar",
@@ -823,6 +877,8 @@ func TestHostConfiguredContainerUpdateConfigurationStatusFileMissing(t *testing.
 }
 
 func TestHostConfiguredContainerUpdateConfigurationStatusNewContent(t *testing.T) {
+	t.Parallel()
+
 	h := &hostConfiguredContainer{
 		configFiles: map[string]string{
 			"/foo": "bar",
@@ -866,6 +922,8 @@ func TestHostConfiguredContainerUpdateConfigurationStatusNewContent(t *testing.T
 }
 
 func TestHostConfiguredContainerUpdateConfigurationStatusReadRuntimeError(t *testing.T) {
+	t.Parallel()
+
 	h := &hostConfiguredContainer{
 		configFiles: map[string]string{
 			"/foo": "bar",

--- a/pkg/container/runtime/docker/docker_integration_test.go
+++ b/pkg/container/runtime/docker/docker_integration_test.go
@@ -16,6 +16,8 @@ import (
 
 // Create() tests.
 func TestContainerCreate(t *testing.T) {
+	t.Parallel()
+
 	r, _ := getDockerRuntime(t)
 
 	cc := &types.ContainerConfig{
@@ -28,6 +30,8 @@ func TestContainerCreate(t *testing.T) {
 }
 
 func TestContainerCreateDelete(t *testing.T) {
+	t.Parallel()
+
 	r, _ := getDockerRuntime(t)
 
 	cc := &types.ContainerConfig{
@@ -45,6 +49,8 @@ func TestContainerCreateDelete(t *testing.T) {
 }
 
 func TestContainerCreateNonExistingImage(t *testing.T) {
+	t.Parallel()
+
 	r, _ := getDockerRuntime(t)
 
 	cc := &types.ContainerConfig{
@@ -57,6 +63,8 @@ func TestContainerCreateNonExistingImage(t *testing.T) {
 }
 
 func TestContainerCreatePullImage(t *testing.T) {
+	t.Parallel()
+
 	// Don't use default version of image, to have better chance it can be removed
 	image := "gcr.io/etcd-development/etcd:v3.3.0"
 
@@ -79,6 +87,8 @@ func TestContainerCreatePullImage(t *testing.T) {
 }
 
 func TestContainerCreateWithArgs(t *testing.T) {
+	t.Parallel()
+
 	args := []string{"--logger=zap"}
 
 	r, d := getDockerRuntime(t)
@@ -105,6 +115,8 @@ func TestContainerCreateWithArgs(t *testing.T) {
 }
 
 func TestContainerCreateWithEntrypoint(t *testing.T) {
+	t.Parallel()
+
 	entrypoint := []string{"/bin/bash"}
 
 	r, d := getDockerRuntime(t)
@@ -131,6 +143,8 @@ func TestContainerCreateWithEntrypoint(t *testing.T) {
 
 // Start() tests.
 func TestContainerStart(t *testing.T) {
+	t.Parallel()
+
 	r, _ := getDockerRuntime(t)
 
 	c := &types.ContainerConfig{
@@ -149,6 +163,8 @@ func TestContainerStart(t *testing.T) {
 
 // Stop() tests.
 func TestContainerStop(t *testing.T) {
+	t.Parallel()
+
 	r, _ := getDockerRuntime(t)
 
 	c := &types.ContainerConfig{
@@ -171,6 +187,8 @@ func TestContainerStop(t *testing.T) {
 
 // Status() tests.
 func TestContainerStatus(t *testing.T) {
+	t.Parallel()
+
 	r, _ := getDockerRuntime(t)
 
 	c := &types.ContainerConfig{
@@ -188,6 +206,8 @@ func TestContainerStatus(t *testing.T) {
 }
 
 func TestContainerStatusNonExistent(t *testing.T) {
+	t.Parallel()
+
 	r, _ := getDockerRuntime(t)
 
 	status, err := r.Status("nonexistent")
@@ -241,6 +261,8 @@ func deleteImage(t *testing.T, image string) {
 
 // imageID() tests.
 func TestImageID(t *testing.T) {
+	t.Parallel()
+
 	_, d := getDockerRuntime(t)
 
 	image := "haproxy:2.0.7-alpine"
@@ -261,6 +283,8 @@ func TestImageID(t *testing.T) {
 }
 
 func TestImageIDMissing(t *testing.T) {
+	t.Parallel()
+
 	_, d := getDockerRuntime(t)
 
 	image := "wrk2:latest"
@@ -279,6 +303,8 @@ func TestImageIDMissing(t *testing.T) {
 
 // pullImage() tests.
 func TestPullImage(t *testing.T) {
+	t.Parallel()
+
 	_, d := getDockerRuntime(t)
 
 	image := "busybox:latest"
@@ -309,6 +335,8 @@ func TestPullImage(t *testing.T) {
 }
 
 func TestContainerEnv(t *testing.T) {
+	t.Parallel()
+
 	env := map[string]string{"foo": "bar"}
 	envSlice := []string{"foo=bar", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
 

--- a/pkg/container/runtime/docker/docker_test.go
+++ b/pkg/container/runtime/docker/docker_test.go
@@ -25,6 +25,8 @@ import (
 
 // New() tests.
 func TestNewClient(t *testing.T) {
+	t.Parallel()
+
 	// TODO does this kind of simple tests make sense? Integration tests calls the same thing
 	// anyway. Or maybe we should simply skip error checking in itegration tests to simplify them?
 	c := &Config{}
@@ -41,6 +43,8 @@ func TestNewClient(t *testing.T) {
 
 // getDockerClient() tests.
 func TestNewClientWithHost(t *testing.T) {
+	t.Parallel()
+
 	config := &Config{
 		Host: "unix:///foo.sock",
 	}
@@ -57,6 +61,8 @@ func TestNewClientWithHost(t *testing.T) {
 
 // sanitizeImageName() tests.
 func TestSanitizeImageName(t *testing.T) {
+	t.Parallel()
+
 	e := "foo:latest"
 
 	if g := sanitizeImageName("foo"); g != e {
@@ -65,6 +71,8 @@ func TestSanitizeImageName(t *testing.T) {
 }
 
 func TestSanitizeImageNameWithTag(t *testing.T) {
+	t.Parallel()
+
 	e := "foo:v0.1.0"
 
 	if g := sanitizeImageName(e); g != e {
@@ -74,6 +82,8 @@ func TestSanitizeImageNameWithTag(t *testing.T) {
 
 // Status() tests.
 func TestStatus(t *testing.T) {
+	t.Parallel()
+
 	es := "running"
 
 	d := &docker{
@@ -106,6 +116,8 @@ func TestStatus(t *testing.T) {
 }
 
 func TestStatusNotFound(t *testing.T) {
+	t.Parallel()
+
 	d := &docker{
 		ctx: context.Background(),
 		cli: &FakeClient{
@@ -126,6 +138,8 @@ func TestStatusNotFound(t *testing.T) {
 }
 
 func TestStatusRuntimeError(t *testing.T) {
+	t.Parallel()
+
 	d := &docker{
 		ctx: context.Background(),
 		cli: &FakeClient{
@@ -142,6 +156,8 @@ func TestStatusRuntimeError(t *testing.T) {
 
 // Copy() tests.
 func TestCopyRuntimeError(t *testing.T) {
+	t.Parallel()
+
 	d := &docker{
 		ctx: context.Background(),
 		cli: &FakeClient{
@@ -158,6 +174,8 @@ func TestCopyRuntimeError(t *testing.T) {
 
 // Read() tests.
 func TestReadRuntimeError(t *testing.T) {
+	t.Parallel()
+
 	p := defaultPath
 
 	d := &docker{
@@ -184,6 +202,8 @@ const (
 )
 
 func TestRead(t *testing.T) {
+	t.Parallel()
+
 	p := defaultPath
 
 	d := &docker{
@@ -218,6 +238,8 @@ func TestRead(t *testing.T) {
 }
 
 func TestReadFileMissing(t *testing.T) {
+	t.Parallel()
+
 	p := defaultPath
 
 	d := &docker{
@@ -253,6 +275,8 @@ DT71fav/qfm/u1/vAAAAAAAAAAAAAAAAAABYbwIOFGnRACgAAA==`)
 }
 
 func TestReadVerifyTarArchive(t *testing.T) {
+	t.Parallel()
+
 	p := defaultPath
 
 	d := &docker{
@@ -271,6 +295,8 @@ func TestReadVerifyTarArchive(t *testing.T) {
 
 // tarToFiles() tests.
 func TestTarToFiles(t *testing.T) {
+	t.Parallel()
+
 	fs, err := tarToFiles(testTar(t))
 	if err != nil {
 		t.Fatalf("Reading should succeed, got: %v", err)
@@ -292,6 +318,8 @@ func TestTarToFiles(t *testing.T) {
 
 // filesToTar() tests.
 func TestFilesToTar(t *testing.T) {
+	t.Parallel()
+
 	tn := "test"
 	f := &types.File{
 		Content: "foo\n",
@@ -335,6 +363,8 @@ func TestFilesToTar(t *testing.T) {
 }
 
 func TestFilesToTarNumericUserGroup(t *testing.T) {
+	t.Parallel()
+
 	tn := 1001
 	f := &types.File{
 		Content: "foo\n",
@@ -367,6 +397,8 @@ func TestFilesToTarNumericUserGroup(t *testing.T) {
 
 // Create() tests.
 func TestCreatePullImageFail(t *testing.T) {
+	t.Parallel()
+
 	d := &docker{
 		ctx: context.Background(),
 		cli: &FakeClient{
@@ -381,9 +413,9 @@ func TestCreatePullImageFail(t *testing.T) {
 	}
 }
 
-func TestCreateBuildPortsFail(t *testing.T) {}
-
 func TestCreateSetUser(t *testing.T) {
+	t.Parallel()
+
 	c := &types.ContainerConfig{
 		User: "test",
 	}
@@ -413,6 +445,8 @@ func TestCreateSetUser(t *testing.T) {
 }
 
 func TestCreateSetUserGroup(t *testing.T) {
+	t.Parallel()
+
 	c := &types.ContainerConfig{
 		User:  "test",
 		Group: "bar",
@@ -445,6 +479,8 @@ func TestCreateSetUserGroup(t *testing.T) {
 }
 
 func TestCreateRuntimeFail(t *testing.T) {
+	t.Parallel()
+
 	d := &docker{
 		ctx: context.Background(),
 		cli: &FakeClient{
@@ -465,10 +501,10 @@ func TestCreateRuntimeFail(t *testing.T) {
 	}
 }
 
-func TestCreate(t *testing.T) {}
-
 // DefaultConfig() tests.
 func TestDefaultConfig(t *testing.T) {
+	t.Parallel()
+
 	if DefaultConfig().Host != client.DefaultDockerHost {
 		t.Fatalf("Host should be set to %s, got %s", client.DefaultDockerHost, DefaultConfig().Host)
 	}
@@ -476,6 +512,8 @@ func TestDefaultConfig(t *testing.T) {
 
 // GetAddress() tests.
 func TestGetAddressNilConfig(t *testing.T) {
+	t.Parallel()
+
 	var c *Config
 
 	if a := c.GetAddress(); a != client.DefaultDockerHost {
@@ -484,6 +522,8 @@ func TestGetAddressNilConfig(t *testing.T) {
 }
 
 func TestGetAddressEmptyConfig(t *testing.T) {
+	t.Parallel()
+
 	c := &Config{}
 
 	if a := c.GetAddress(); a != client.DefaultDockerHost {
@@ -492,6 +532,8 @@ func TestGetAddressEmptyConfig(t *testing.T) {
 }
 
 func TestGetAddress(t *testing.T) {
+	t.Parallel()
+
 	f := "foo"
 	c := &Config{
 		Host: f,
@@ -504,6 +546,8 @@ func TestGetAddress(t *testing.T) {
 
 // convertContainerConfig() tests.
 func TestConvertContainerConfigEnvVariables(t *testing.T) {
+	t.Parallel()
+
 	c := &types.ContainerConfig{
 		Env: map[string]string{"foo": "bar"},
 	}

--- a/pkg/controlplane/controlplane_test.go
+++ b/pkg/controlplane/controlplane_test.go
@@ -98,6 +98,8 @@ func controlplaneYAML(t *testing.T) string {
 }
 
 func TestControlplaneFromYaml(t *testing.T) {
+	t.Parallel()
+
 	co, err := FromYaml([]byte(controlplaneYAML(t)))
 	if err != nil {
 		t.Fatalf("Creating controlplane from YAML should succeed, got: %v", err)
@@ -122,6 +124,8 @@ func TestControlplaneFromYaml(t *testing.T) {
 
 // New() tests.
 func TestControlplaneNewValidate(t *testing.T) {
+	t.Parallel()
+
 	c := &Controlplane{}
 
 	if _, err := c.New(); err == nil {
@@ -130,6 +134,8 @@ func TestControlplaneNewValidate(t *testing.T) {
 }
 
 func TestControlplaneDestroyNoState(t *testing.T) {
+	t.Parallel()
+
 	y := controlplaneYAML(t)
 
 	y += `destroy: true`
@@ -140,6 +146,8 @@ func TestControlplaneDestroyNoState(t *testing.T) {
 }
 
 func TestControlplaneDestroyValidateState(t *testing.T) {
+	t.Parallel()
+
 	y := controlplaneYAML(t)
 
 	y += `destroy: true
@@ -153,6 +161,8 @@ state:
 }
 
 func TestControlplaneDestroyValidState(t *testing.T) {
+	t.Parallel()
+
 	y := `destroy: true
 state:
   foo:
@@ -176,6 +186,8 @@ state:
 }
 
 func TestControlplaneNewPKIIntegration(t *testing.T) {
+	t.Parallel()
+
 	pki := &pki.PKI{
 		Etcd: &pki.Etcd{
 			ClientCNs: []string{"kube-apiserver", "root"},

--- a/pkg/controlplane/kube-apiserver_test.go
+++ b/pkg/controlplane/kube-apiserver_test.go
@@ -19,6 +19,8 @@ const (
 )
 
 func TestKubeAPIServerToHostConfiguredContainer(t *testing.T) {
+	t.Parallel()
+
 	cert := types.Certificate(utiltest.GenerateX509Certificate(t))
 	privateKey := types.PrivateKey(utiltest.GenerateRSAPrivateKey(t))
 
@@ -67,7 +69,11 @@ func TestKubeAPIServerToHostConfiguredContainer(t *testing.T) {
 }
 
 // Validate() tests.
-func TestKubeAPIServerValidate(t *testing.T) { //nolint:funlen
+//
+//nolint:funlen
+func TestKubeAPIServerValidate(t *testing.T) {
+	t.Parallel()
+
 	cert := types.Certificate(utiltest.GenerateX509Certificate(t))
 	privateKey := types.PrivateKey(utiltest.GenerateRSAPrivateKey(t))
 
@@ -199,6 +205,8 @@ func TestKubeAPIServerValidate(t *testing.T) { //nolint:funlen
 		c := c
 
 		t.Run(n, func(t *testing.T) {
+			t.Parallel()
+
 			err := c.Config.Validate()
 			if !c.Error && err != nil {
 				t.Errorf("didn't expect error, got: %v", err)
@@ -212,6 +220,8 @@ func TestKubeAPIServerValidate(t *testing.T) { //nolint:funlen
 }
 
 func TestKubeAPIServerConfigFiles(t *testing.T) {
+	t.Parallel()
+
 	cert := types.Certificate(utiltest.GenerateX509Certificate(t))
 	privateKey := types.PrivateKey(utiltest.GenerateRSAPrivateKey(t))
 
@@ -260,6 +270,8 @@ func TestKubeAPIServerConfigFiles(t *testing.T) {
 
 // New() tests.
 func TestKubeAPIServerNewEmptyHost(t *testing.T) {
+	t.Parallel()
+
 	c := &KubeAPIServer{}
 
 	k, err := c.New()

--- a/pkg/controlplane/kube-controller-manager_test.go
+++ b/pkg/controlplane/kube-controller-manager_test.go
@@ -10,7 +10,10 @@ import (
 	"github.com/flexkube/libflexkube/pkg/types"
 )
 
-func TestKubeControllerManagerValidate(t *testing.T) { //nolint:funlen
+//nolint:funlen
+func TestKubeControllerManagerValidate(t *testing.T) {
+	t.Parallel()
+
 	hostConfig := &host.Host{
 		DirectConfig: &direct.Config{},
 	}
@@ -110,6 +113,8 @@ func TestKubeControllerManagerValidate(t *testing.T) { //nolint:funlen
 		c := c
 
 		t.Run(n, func(t *testing.T) {
+			t.Parallel()
+
 			err := c.Config.Validate()
 			if !c.Error && err != nil {
 				t.Errorf("didn't expect error, got: %v", err)
@@ -123,6 +128,8 @@ func TestKubeControllerManagerValidate(t *testing.T) { //nolint:funlen
 }
 
 func TestKubeControllerManagerToHostConfiguredContainer(t *testing.T) {
+	t.Parallel()
+
 	pki := utiltest.GeneratePKI(t)
 
 	kcm := &KubeControllerManager{
@@ -161,6 +168,8 @@ func TestKubeControllerManagerToHostConfiguredContainer(t *testing.T) {
 
 // New() tests.
 func TestKubeControllerManagerNewEmptyHost(t *testing.T) {
+	t.Parallel()
+
 	ks := &KubeControllerManager{}
 
 	k, err := ks.New()

--- a/pkg/controlplane/kube-scheduler_test.go
+++ b/pkg/controlplane/kube-scheduler_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestKubeSchedulerToHostConfiguredContainer(t *testing.T) {
+	t.Parallel()
+
 	pki := utiltest.GeneratePKI(t)
 
 	ks := &KubeScheduler{
@@ -49,6 +51,8 @@ func TestKubeSchedulerToHostConfiguredContainer(t *testing.T) {
 
 // New() tests.
 func TestKubeSchedulerNewEmptyHost(t *testing.T) {
+	t.Parallel()
+
 	ks := &KubeScheduler{}
 
 	k, err := ks.New()
@@ -62,7 +66,11 @@ func TestKubeSchedulerNewEmptyHost(t *testing.T) {
 }
 
 // Validate() tests.
-func TestKubeSchedulerValidate(t *testing.T) { //nolint:funlen
+//
+//nolint:funlen
+func TestKubeSchedulerValidate(t *testing.T) {
+	t.Parallel()
+
 	pki := utiltest.GeneratePKI(t)
 
 	hostConfig := &host.Host{
@@ -121,6 +129,8 @@ func TestKubeSchedulerValidate(t *testing.T) { //nolint:funlen
 		c := c
 
 		t.Run(n, func(t *testing.T) {
+			t.Parallel()
+
 			err := c.Config.Validate()
 			if !c.Error && err != nil {
 				t.Errorf("didn't expect error, got: %v", err)

--- a/pkg/controlplane/validate_test.go
+++ b/pkg/controlplane/validate_test.go
@@ -37,6 +37,8 @@ func validValidator(t *testing.T) validator {
 }
 
 func TestValidate(t *testing.T) {
+	t.Parallel()
+
 	v := validValidator(t)
 
 	if err := v.validate(true); err != nil {
@@ -45,6 +47,8 @@ func TestValidate(t *testing.T) {
 }
 
 func TestValidateMarshalFail(t *testing.T) {
+	t.Parallel()
+
 	v := validValidator(t)
 
 	v.YAML = map[string]interface{}{

--- a/pkg/etcd/cluster_test.go
+++ b/pkg/etcd/cluster_test.go
@@ -24,7 +24,11 @@ import (
 )
 
 // FromYAML() tests.
+//
+//nolint:funlen
 func TestClusterFromYaml(t *testing.T) {
+	t.Parallel()
+
 	c := `
 ssh:
   user: "core"
@@ -89,6 +93,8 @@ members:
 
 // New() tests.
 func TestNewValidateFail(t *testing.T) {
+	t.Parallel()
+
 	config := &Cluster{}
 
 	if _, err := config.New(); err == nil {
@@ -98,6 +104,8 @@ func TestNewValidateFail(t *testing.T) {
 
 // Validate() tests.
 func TestValidateValidateMembers(t *testing.T) {
+	t.Parallel()
+
 	config := &Cluster{
 		Members: map[string]Member{
 			"foo": {},
@@ -110,6 +118,8 @@ func TestValidateValidateMembers(t *testing.T) {
 }
 
 func TestValidateValidatePass(t *testing.T) {
+	t.Parallel()
+
 	cert := utiltest.GenerateX509Certificate(t)
 	key := utiltest.GenerateRSAPrivateKey(t)
 
@@ -132,6 +142,8 @@ func TestValidateValidatePass(t *testing.T) {
 }
 
 func TestValidateValidateBadCACertificate(t *testing.T) {
+	t.Parallel()
+
 	cert := utiltest.GenerateX509Certificate(t)
 	key := utiltest.GenerateRSAPrivateKey(t)
 
@@ -156,6 +168,8 @@ func TestValidateValidateBadCACertificate(t *testing.T) {
 
 // getExistingEndpoints() tests.
 func TestExistingEndpointsNoEndpoints(t *testing.T) {
+	t.Parallel()
+
 	c := &cluster{}
 	if len(c.getExistingEndpoints()) != 0 {
 		t.Fatalf("No endpoints should be returned for empty cluster")
@@ -163,6 +177,8 @@ func TestExistingEndpointsNoEndpoints(t *testing.T) {
 }
 
 func TestExistingEndpoints(t *testing.T) {
+	t.Parallel()
+
 	c := &cluster{
 		containers: getContainers(t),
 		members: map[string]*member{
@@ -183,6 +199,8 @@ func TestExistingEndpoints(t *testing.T) {
 
 // firstMember() tests.
 func TestFirstMemberNoMembers(t *testing.T) {
+	t.Parallel()
+
 	c := &cluster{}
 
 	if _, err := c.firstMember(); err == nil {
@@ -191,6 +209,8 @@ func TestFirstMemberNoMembers(t *testing.T) {
 }
 
 func TestFirstMember(t *testing.T) {
+	t.Parallel()
+
 	c := &cluster{
 		members: map[string]*member{
 			"foo": {},
@@ -241,6 +261,8 @@ func getFakeHostConfiguredContainer() *container.HostConfiguredContainer {
 
 // getClient() tests.
 func TestGetClientEmptyCluster(t *testing.T) {
+	t.Parallel()
+
 	c := &cluster{}
 	if _, err := c.getClient(); err == nil {
 		t.Fatalf("Getting client on empty cluster should fail")
@@ -248,6 +270,8 @@ func TestGetClientEmptyCluster(t *testing.T) {
 }
 
 func TestGetClientForwardFail(t *testing.T) {
+	t.Parallel()
+
 	c := &cluster{
 		containers: getContainers(t),
 		members: map[string]*member{
@@ -273,6 +297,8 @@ func TestGetClientForwardFail(t *testing.T) {
 }
 
 func TestGetClient(t *testing.T) {
+	t.Parallel()
+
 	c := &cluster{
 		containers: getContainers(t),
 		members: map[string]*member{
@@ -296,6 +322,8 @@ func TestGetClient(t *testing.T) {
 
 // membersToRemove() tests.
 func TestMembersToRemove(t *testing.T) {
+	t.Parallel()
+
 	cc := &container.Containers{
 		PreviousState: container.ContainersState{
 			"foo": getFakeHostConfiguredContainer(),
@@ -324,6 +352,8 @@ func TestMembersToRemove(t *testing.T) {
 
 // membersToAdd() tests.
 func TestMembersToAdd(t *testing.T) {
+	t.Parallel()
+
 	cc := &container.Containers{
 		PreviousState: container.ContainersState{
 			"bar": getFakeHostConfiguredContainer(),
@@ -352,6 +382,8 @@ func TestMembersToAdd(t *testing.T) {
 
 // updateMembers() tests.
 func TestUpdateMembersNoUpdates(t *testing.T) {
+	t.Parallel()
+
 	cc := &container.Containers{
 		PreviousState: container.ContainersState{
 			"foo": getFakeHostConfiguredContainer(),
@@ -390,6 +422,8 @@ func TestUpdateMembersNoUpdates(t *testing.T) {
 }
 
 func TestUpdateMembersRemoveMember(t *testing.T) {
+	t.Parallel()
+
 	c := &cluster{
 		containers: getContainers(t),
 		members: map[string]*member{
@@ -430,6 +464,8 @@ func TestUpdateMembersRemoveMember(t *testing.T) {
 }
 
 func TestUpdateMembersAddMember(t *testing.T) {
+	t.Parallel()
+
 	cc := &container.Containers{
 		DesiredState: container.ContainersState{
 			"foo": getFakeHostConfiguredContainer(),
@@ -476,6 +512,8 @@ func TestUpdateMembersAddMember(t *testing.T) {
 
 // Deploy() tests.
 func TestDeploy(t *testing.T) {
+	t.Parallel()
+
 	cc := &container.Containers{
 		DesiredState: container.ContainersState{
 			"foo": getFakeHostConfiguredContainer(),
@@ -503,6 +541,8 @@ func TestDeploy(t *testing.T) {
 }
 
 func TestDeployUpdateMembers(t *testing.T) {
+	t.Parallel()
+
 	cc := &container.Containers{
 		PreviousState: container.ContainersState{
 			"bar": getFakeHostConfiguredContainer(),
@@ -533,6 +573,8 @@ func TestDeployUpdateMembers(t *testing.T) {
 }
 
 func TestClusterNewPKIIntegration(t *testing.T) {
+	t.Parallel()
+
 	pki := &pki.PKI{
 		Etcd: &pki.Etcd{
 			Peers: map[string]string{

--- a/pkg/etcd/member_internal_test.go
+++ b/pkg/etcd/member_internal_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestNewCluster(t *testing.T) {
+	t.Parallel()
+
 	m := &member{
 		config: &Member{
 			NewCluster: true,
@@ -42,6 +44,8 @@ func TestNewCluster(t *testing.T) {
 }
 
 func TestExistingCluster(t *testing.T) {
+	t.Parallel()
+
 	m := &member{
 		config: &Member{
 			NewCluster: false,
@@ -70,6 +74,8 @@ func TestExistingCluster(t *testing.T) {
 
 // peerURLs() tests.
 func TestPeerURLs(t *testing.T) {
+	t.Parallel()
+
 	m := &member{
 		config: &Member{
 			PeerAddress: "1.1.1.1",
@@ -84,6 +90,8 @@ func TestPeerURLs(t *testing.T) {
 
 // forwardEndpoints() tests.
 func TestForwardEndpoints(t *testing.T) {
+	t.Parallel()
+
 	m := &member{
 		config: &Member{
 			PeerAddress: "127.0.0.1",
@@ -104,6 +112,8 @@ func TestForwardEndpoints(t *testing.T) {
 }
 
 func TestForwardEndpointsFail(t *testing.T) {
+	t.Parallel()
+
 	m := &member{
 		config: &Member{
 			PeerAddress: "127.0.0.1",
@@ -120,6 +130,8 @@ func TestForwardEndpointsFail(t *testing.T) {
 
 // getID() tests.
 func TestGetIDFailToListMembers(t *testing.T) {
+	t.Parallel()
+
 	f := &fakeClient{
 		memberListF: func(context context.Context) (*clientv3.MemberListResponse, error) {
 			return nil, fmt.Errorf("expected")
@@ -134,6 +146,8 @@ func TestGetIDFailToListMembers(t *testing.T) {
 }
 
 func TestGetIDNotFound(t *testing.T) {
+	t.Parallel()
+
 	f := &fakeClient{
 		memberListF: func(context context.Context) (*clientv3.MemberListResponse, error) {
 			return &clientv3.MemberListResponse{}, nil
@@ -153,6 +167,8 @@ func TestGetIDNotFound(t *testing.T) {
 }
 
 func TestGetIDByName(t *testing.T) {
+	t.Parallel()
+
 	f := &fakeClient{
 		memberListF: func(context context.Context) (*clientv3.MemberListResponse, error) {
 			return &clientv3.MemberListResponse{
@@ -183,6 +199,8 @@ func TestGetIDByName(t *testing.T) {
 }
 
 func TestGetIDByPeerURL(t *testing.T) {
+	t.Parallel()
+
 	f := &fakeClient{
 		memberListF: func(context context.Context) (*clientv3.MemberListResponse, error) {
 			return &clientv3.MemberListResponse{
@@ -215,6 +233,8 @@ func TestGetIDByPeerURL(t *testing.T) {
 
 // getEtcdClient() tests.
 func TestGetEtcdClientNoEndpoints(t *testing.T) {
+	t.Parallel()
+
 	m := &member{
 		config: &Member{
 			CACertificate: utiltest.GenerateX509Certificate(t),
@@ -227,6 +247,8 @@ func TestGetEtcdClientNoEndpoints(t *testing.T) {
 }
 
 func TestGetEtcdClient(t *testing.T) {
+	t.Parallel()
+
 	m := &member{
 		config: &Member{
 			PeerCertificate: "",
@@ -247,6 +269,8 @@ const testID = 1
 
 // remove() tests.
 func TestRemove(t *testing.T) {
+	t.Parallel()
+
 	f := &fakeClient{
 		memberListF: func(context context.Context) (*clientv3.MemberListResponse, error) {
 			return &clientv3.MemberListResponse{
@@ -276,6 +300,8 @@ func TestRemove(t *testing.T) {
 }
 
 func TestRemoveNonExistent(t *testing.T) {
+	t.Parallel()
+
 	f := &fakeClient{
 		memberListF: func(context context.Context) (*clientv3.MemberListResponse, error) {
 			return &clientv3.MemberListResponse{
@@ -295,6 +321,8 @@ func TestRemoveNonExistent(t *testing.T) {
 }
 
 func TestRemoveMemberFail(t *testing.T) {
+	t.Parallel()
+
 	f := &fakeClient{
 		memberListF: func(context context.Context) (*clientv3.MemberListResponse, error) {
 			return &clientv3.MemberListResponse{
@@ -328,6 +356,8 @@ func TestRemoveMemberFail(t *testing.T) {
 }
 
 func TestRemoveGetIDFail(t *testing.T) {
+	t.Parallel()
+
 	f := &fakeClient{
 		memberListF: func(context context.Context) (*clientv3.MemberListResponse, error) {
 			return nil, fmt.Errorf("expected")
@@ -343,6 +373,8 @@ func TestRemoveGetIDFail(t *testing.T) {
 
 // addMember() tests.
 func TestAddMember(t *testing.T) {
+	t.Parallel()
+
 	f := &fakeClient{
 		memberListF: func(context context.Context) (*clientv3.MemberListResponse, error) {
 			return &clientv3.MemberListResponse{
@@ -370,6 +402,8 @@ func TestAddMember(t *testing.T) {
 }
 
 func TestAddMemberAlreadyExists(t *testing.T) {
+	t.Parallel()
+
 	f := &fakeClient{
 		memberListF: func(context context.Context) (*clientv3.MemberListResponse, error) {
 			return &clientv3.MemberListResponse{
@@ -399,6 +433,8 @@ func TestAddMemberAlreadyExists(t *testing.T) {
 }
 
 func TestAddMemberFail(t *testing.T) {
+	t.Parallel()
+
 	f := &fakeClient{
 		memberListF: func(context context.Context) (*clientv3.MemberListResponse, error) {
 			return &clientv3.MemberListResponse{
@@ -426,6 +462,8 @@ func TestAddMemberFail(t *testing.T) {
 }
 
 func TestAddGetIDFail(t *testing.T) {
+	t.Parallel()
+
 	f := &fakeClient{
 		memberListF: func(context context.Context) (*clientv3.MemberListResponse, error) {
 			return nil, fmt.Errorf("expected")

--- a/pkg/etcd/member_test.go
+++ b/pkg/etcd/member_test.go
@@ -15,6 +15,8 @@ const (
 )
 
 func TestMemberToHostConfiguredContainer(t *testing.T) {
+	t.Parallel()
+
 	cert := utiltest.GenerateX509Certificate(t)
 	privateKey := utiltest.GenerateRSAPrivateKey(t)
 
@@ -72,6 +74,8 @@ func validMember(t *testing.T) *etcd.Member {
 //
 //nolint:funlen
 func TestValidate(t *testing.T) {
+	t.Parallel()
+
 	cases := map[string]struct {
 		mutator     func(m *etcd.Member) *etcd.Member
 		expectError bool
@@ -150,6 +154,8 @@ func TestValidate(t *testing.T) {
 		p := p
 
 		t.Run(c, func(t *testing.T) {
+			t.Parallel()
+
 			m := p.mutator(validMember(t))
 			err := m.Validate()
 

--- a/pkg/helm/release/release_internal_test.go
+++ b/pkg/helm/release/release_internal_test.go
@@ -6,6 +6,8 @@ import (
 )
 
 func TestRetryOnEtcdErrorRetry(t *testing.T) {
+	t.Parallel()
+
 	calls := 0
 
 	if err := retryOnEtcdError(func() error {
@@ -22,6 +24,8 @@ func TestRetryOnEtcdErrorRetry(t *testing.T) {
 }
 
 func TestRetryOnEtcdErrorDifferentError(t *testing.T) {
+	t.Parallel()
+
 	calls := 0
 
 	if err := retryOnEtcdError(func() error {
@@ -38,6 +42,8 @@ func TestRetryOnEtcdErrorDifferentError(t *testing.T) {
 }
 
 func TestRetryOnEtcdErrorNoError(t *testing.T) {
+	t.Parallel()
+
 	calls := 0
 
 	if err := retryOnEtcdError(func() error {
@@ -54,6 +60,8 @@ func TestRetryOnEtcdErrorNoError(t *testing.T) {
 }
 
 func TestRetryOnEtcdErrorTranscientError(t *testing.T) {
+	t.Parallel()
+
 	calls := 0
 
 	if err := retryOnEtcdError(func() error {

--- a/pkg/helm/release/release_test.go
+++ b/pkg/helm/release/release_test.go
@@ -10,6 +10,8 @@ import (
 
 // New() tests.
 func TestConfigNewBadKubeconfig(t *testing.T) {
+	t.Parallel()
+
 	config := &release.Config{
 		// Put content of your kubeconfig file here.
 		Kubeconfig: "",
@@ -96,11 +98,15 @@ func newRelease(t *testing.T) release.Release {
 }
 
 func TestConfigNew(t *testing.T) {
+	t.Parallel()
+
 	newRelease(t)
 }
 
 // Validate() tests.
 func TestConfigValidateEmptyNamespace(t *testing.T) {
+	t.Parallel()
+
 	c := newConfig(t)
 	c.Namespace = ""
 
@@ -110,6 +116,8 @@ func TestConfigValidateEmptyNamespace(t *testing.T) {
 }
 
 func TestConfigValidateEmptyName(t *testing.T) {
+	t.Parallel()
+
 	c := newConfig(t)
 	c.Name = ""
 
@@ -119,6 +127,8 @@ func TestConfigValidateEmptyName(t *testing.T) {
 }
 
 func TestConfigValidateEmptyChart(t *testing.T) {
+	t.Parallel()
+
 	c := newConfig(t)
 	c.Chart = ""
 
@@ -128,6 +138,8 @@ func TestConfigValidateEmptyChart(t *testing.T) {
 }
 
 func TestConfigValidateBadValues(t *testing.T) {
+	t.Parallel()
+
 	c := newConfig(t)
 	c.Values = "asd"
 
@@ -138,6 +150,8 @@ func TestConfigValidateBadValues(t *testing.T) {
 
 // ValidateChart() tests.
 func TestReleaseValidateChartBad(t *testing.T) {
+	t.Parallel()
+
 	r := newRelease(t)
 
 	if err := r.ValidateChart(); err == nil {

--- a/pkg/host/host_test.go
+++ b/pkg/host/host_test.go
@@ -10,6 +10,8 @@ import (
 
 // New() tests.
 func TestNew(t *testing.T) {
+	t.Parallel()
+
 	h := BuildConfig(Host{
 		SSHConfig: &ssh.Config{
 			Address:  "localhost",
@@ -23,6 +25,8 @@ func TestNew(t *testing.T) {
 }
 
 func TestNewValidate(t *testing.T) {
+	t.Parallel()
+
 	h := &Host{}
 
 	if _, err := h.New(); err == nil {
@@ -32,6 +36,8 @@ func TestNewValidate(t *testing.T) {
 
 // Validate() tests.
 func TestValidate(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		Host    *Host
 		Message string
@@ -63,6 +69,8 @@ func TestValidate(t *testing.T) {
 		c := c
 
 		t.Run(fmt.Sprintf("%d", n), func(t *testing.T) {
+			t.Parallel()
+
 			err := c.Host.Validate()
 			if c.Error && err == nil {
 				t.Fatalf(c.Message)
@@ -76,6 +84,8 @@ func TestValidate(t *testing.T) {
 
 // Connect() tests.
 func TestConnect(t *testing.T) {
+	t.Parallel()
+
 	h := Host{
 		DirectConfig: &direct.Config{},
 	}
@@ -92,6 +102,8 @@ func TestConnect(t *testing.T) {
 
 // ForwardUnixSocket() tests.
 func TestForwardUnixSocket(t *testing.T) {
+	t.Parallel()
+
 	h := Host{
 		DirectConfig: &direct.Config{},
 	}
@@ -113,6 +125,8 @@ func TestForwardUnixSocket(t *testing.T) {
 
 // ForwardTCP() tests.
 func TestForwardTCP(t *testing.T) {
+	t.Parallel()
+
 	h := Host{
 		DirectConfig: &direct.Config{},
 	}
@@ -134,6 +148,8 @@ func TestForwardTCP(t *testing.T) {
 
 // BuildConfig() tests.
 func TestBuildConfigDirectByDefault(t *testing.T) {
+	t.Parallel()
+
 	h := BuildConfig(Host{}, Host{})
 	if err := h.Validate(); err != nil {
 		t.Errorf("Config returned by default should be valid, got: %v", err)
@@ -144,7 +160,9 @@ func TestBuildConfigDirectByDefault(t *testing.T) {
 	}
 }
 
-func TestBuildConfigFirstPriotityDirect(t *testing.T) {
+func TestBuildConfigFirstPriorityDirect(t *testing.T) {
+	t.Parallel()
+
 	c := Host{
 		DirectConfig: &direct.Config{},
 	}
@@ -164,6 +182,8 @@ func TestBuildConfigFirstPriotityDirect(t *testing.T) {
 }
 
 func TestBuildConfigFirstPriotitySSH(t *testing.T) {
+	t.Parallel()
+
 	c := Host{
 		SSHConfig: &ssh.Config{
 			Address:  "foo",
@@ -186,6 +206,8 @@ func TestBuildConfigFirstPriotitySSH(t *testing.T) {
 }
 
 func TestBuildConfigSSH(t *testing.T) {
+	t.Parallel()
+
 	u := Host{
 		SSHConfig: &ssh.Config{
 			Address: "foo",

--- a/pkg/host/transport/direct/direct_test.go
+++ b/pkg/host/transport/direct/direct_test.go
@@ -6,6 +6,8 @@ import (
 )
 
 func TestNew(t *testing.T) {
+	t.Parallel()
+
 	d := &Config{}
 
 	di, err := d.New()
@@ -19,6 +21,8 @@ func TestNew(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
+	t.Parallel()
+
 	d := &Config{}
 
 	if err := d.Validate(); err != nil {
@@ -27,6 +31,8 @@ func TestValidate(t *testing.T) {
 }
 
 func TestForwardUnixSocket(t *testing.T) {
+	t.Parallel()
+
 	d := &direct{}
 	p := "/foo"
 
@@ -36,6 +42,8 @@ func TestForwardUnixSocket(t *testing.T) {
 }
 
 func TestConnect(t *testing.T) {
+	t.Parallel()
+
 	d := &direct{}
 	if _, err := d.Connect(); err != nil {
 		t.Fatalf("Connect should always work, got: %v", err)
@@ -43,6 +51,8 @@ func TestConnect(t *testing.T) {
 }
 
 func TestForwardTCP(t *testing.T) {
+	t.Parallel()
+
 	d := &direct{}
 	a := "localhost:80"
 
@@ -52,6 +62,8 @@ func TestForwardTCP(t *testing.T) {
 }
 
 func TestForwardTCPBadAddress(t *testing.T) {
+	t.Parallel()
+
 	d := &direct{}
 	a := "localhost"
 

--- a/pkg/host/transport/ssh/defaults_test.go
+++ b/pkg/host/transport/ssh/defaults_test.go
@@ -12,6 +12,8 @@ const (
 )
 
 func TestBuildConfig(t *testing.T) { //nolint:funlen
+	t.Parallel()
+
 	cases := []struct {
 		config   *Config
 		defaults *Config
@@ -388,6 +390,8 @@ func TestBuildConfig(t *testing.T) { //nolint:funlen
 		c := c
 
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			t.Parallel()
+
 			if nc := BuildConfig(c.config, c.defaults); !reflect.DeepEqual(nc, c.result) {
 				t.Fatalf("expected %+v, got %+v", c.result, nc)
 			}

--- a/pkg/host/transport/ssh/ssh_integration_test.go
+++ b/pkg/host/transport/ssh/ssh_integration_test.go
@@ -19,6 +19,8 @@ import (
 const testServerAddr = "/run/test.sock"
 
 func TestPasswordAuth(t *testing.T) {
+	t.Parallel()
+
 	pass, err := ioutil.ReadFile("/home/core/.password")
 	if err != nil {
 		t.Fatalf("reading password shouldn't fail, got: %v", err)
@@ -45,6 +47,8 @@ func TestPasswordAuth(t *testing.T) {
 }
 
 func TestPasswordAuthFail(t *testing.T) {
+	t.Parallel()
+
 	c := &Config{
 		Address:           "localhost",
 		User:              "core",
@@ -66,6 +70,8 @@ func TestPasswordAuthFail(t *testing.T) {
 }
 
 func TestPrivateKeyAuth(t *testing.T) {
+	t.Parallel()
+
 	s := withPrivateKey(t)
 
 	if _, err := s.Connect(); err != nil {
@@ -74,6 +80,8 @@ func TestPrivateKeyAuth(t *testing.T) {
 }
 
 func withPrivateKey(t *testing.T) transport.Interface {
+	t.Parallel()
+
 	key, err := ioutil.ReadFile("/home/core/.ssh/id_rsa")
 	if err != nil {
 		t.Fatalf("reading SSH private key shouldn't fail, got: %v", err)
@@ -98,6 +106,8 @@ func withPrivateKey(t *testing.T) transport.Interface {
 }
 
 func TestForwardUnixSocketFull(t *testing.T) {
+	t.Parallel()
+
 	ssh := withPrivateKey(t)
 	expectedMessage := "foo"
 	expectedResponse := "bar"

--- a/pkg/host/transport/ssh/ssh_test.go
+++ b/pkg/host/transport/ssh/ssh_test.go
@@ -25,7 +25,15 @@ const (
 	authMethods      = 1
 )
 
+// This test may access SSHAuthSockEnv environment variable,
+// which is global variable, so to keep things stable, don't run it in parallel.
+//
+//nolint:paralleltest
 func TestNew(t *testing.T) {
+	if err := os.Unsetenv(SSHAuthSockEnv); err != nil {
+		t.Fatalf("failed unsetting environment variable %q: %v", SSHAuthSockEnv, err)
+	}
+
 	c := &Config{
 		Address:           "localhost",
 		User:              "root",
@@ -41,6 +49,10 @@ func TestNew(t *testing.T) {
 	}
 }
 
+// This test may access SSHAuthSockEnv environment variable,
+// which is global variable, so to keep things stable, don't run it in parallel.
+//
+//nolint:paralleltest
 func TestNewSetPassword(t *testing.T) {
 	if err := os.Unsetenv(SSHAuthSockEnv); err != nil {
 		t.Fatalf("failed unsetting environment variable %q: %v", SSHAuthSockEnv, err)
@@ -66,7 +78,15 @@ func TestNewSetPassword(t *testing.T) {
 	}
 }
 
+// This test may access SSHAuthSockEnv environment variable,
+// which is global variable, so to keep things stable, don't run it in parallel.
+//
+//nolint:paralleltest
 func TestNewSetPrivateKey(t *testing.T) {
+	if err := os.Unsetenv(SSHAuthSockEnv); err != nil {
+		t.Fatalf("failed unsetting environment variable %q: %v", SSHAuthSockEnv, err)
+	}
+
 	c := &Config{
 		Address:           "localhost",
 		User:              "root",
@@ -88,6 +108,8 @@ func TestNewSetPrivateKey(t *testing.T) {
 }
 
 func TestNewValidate(t *testing.T) {
+	t.Parallel()
+
 	c := &Config{}
 	if _, err := c.New(); err == nil {
 		t.Fatalf("creating new SSH object should validate it")
@@ -96,6 +118,8 @@ func TestNewValidate(t *testing.T) {
 
 // Validate() tests.
 func TestValidateRequireAddress(t *testing.T) {
+	t.Parallel()
+
 	c := &Config{
 		User:              "root",
 		Password:          "foo",
@@ -109,7 +133,15 @@ func TestValidateRequireAddress(t *testing.T) {
 	}
 }
 
+// This test may access SSHAuthSockEnv environment variable,
+// which is global variable, so to keep things stable, don't run it in parallel.
+//
+//nolint:paralleltest
 func TestValidateRequireAuth(t *testing.T) {
+	if err := os.Unsetenv(SSHAuthSockEnv); err != nil {
+		t.Fatalf("failed unsetting environment variable %q: %v", SSHAuthSockEnv, err)
+	}
+
 	c := &Config{
 		Address:           "localhost",
 		User:              "root",
@@ -124,6 +156,8 @@ func TestValidateRequireAuth(t *testing.T) {
 }
 
 func TestValidateRequireUser(t *testing.T) {
+	t.Parallel()
+
 	c := &Config{
 		Address:           "localhost",
 		Password:          "foo",
@@ -137,21 +171,9 @@ func TestValidateRequireUser(t *testing.T) {
 	}
 }
 
-func TestValidateRequireAuthMethod(t *testing.T) {
-	c := &Config{
-		Address:           "localhost",
-		User:              "root",
-		ConnectionTimeout: "30s",
-		RetryTimeout:      "60s",
-		RetryInterval:     "1s",
-		Port:              Port,
-	}
-	if err := c.Validate(); err == nil {
-		t.Fatalf("validating SSH configuration should require at least one authentication method")
-	}
-}
-
 func TestValidateRequireConnectionTimeout(t *testing.T) {
+	t.Parallel()
+
 	c := &Config{
 		Address:       "localhost",
 		User:          "root",
@@ -166,6 +188,8 @@ func TestValidateRequireConnectionTimeout(t *testing.T) {
 }
 
 func TestValidateRequireRetryTimeout(t *testing.T) {
+	t.Parallel()
+
 	c := &Config{
 		Address:           "localhost",
 		User:              "root",
@@ -180,6 +204,8 @@ func TestValidateRequireRetryTimeout(t *testing.T) {
 }
 
 func TestValidateRequireRetryInterval(t *testing.T) {
+	t.Parallel()
+
 	c := &Config{
 		Address:           "localhost",
 		User:              "root",
@@ -194,6 +220,8 @@ func TestValidateRequireRetryInterval(t *testing.T) {
 }
 
 func TestValidateRequirePort(t *testing.T) {
+	t.Parallel()
+
 	c := &Config{
 		Address:           "localhost",
 		User:              "root",
@@ -208,6 +236,8 @@ func TestValidateRequirePort(t *testing.T) {
 }
 
 func TestValidateParseConnectionTimeout(t *testing.T) {
+	t.Parallel()
+
 	c := &Config{
 		Address:           "localhost",
 		User:              "root",
@@ -223,6 +253,8 @@ func TestValidateParseConnectionTimeout(t *testing.T) {
 }
 
 func TestValidateParseRetryTimeout(t *testing.T) {
+	t.Parallel()
+
 	c := &Config{
 		Address:           "localhost",
 		User:              "root",
@@ -238,6 +270,8 @@ func TestValidateParseRetryTimeout(t *testing.T) {
 }
 
 func TestValidateParseRetryInterval(t *testing.T) {
+	t.Parallel()
+
 	c := &Config{
 		Address:           "localhost",
 		User:              "root",
@@ -253,6 +287,8 @@ func TestValidateParseRetryInterval(t *testing.T) {
 }
 
 func TestValidateParsePrivateKey(t *testing.T) {
+	t.Parallel()
+
 	c := &Config{
 		Address:           "localhost",
 		User:              "root",
@@ -284,6 +320,8 @@ func generateRSAPrivateKey(t *testing.T) string {
 }
 
 func TestHandleClientLocalRemote(t *testing.T) {
+	t.Parallel()
+
 	server, client := net.Pipe()
 
 	remoteServer, remoteClient := net.Pipe()
@@ -304,6 +342,8 @@ func TestHandleClientLocalRemote(t *testing.T) {
 }
 
 func TestHandleClientRemoteLocal(t *testing.T) {
+	t.Parallel()
+
 	server, client := net.Pipe()
 
 	remoteServer, remoteClient := net.Pipe()
@@ -324,6 +364,8 @@ func TestHandleClientRemoteLocal(t *testing.T) {
 }
 
 func TestHandleClientBiDirectional(t *testing.T) {
+	t.Parallel()
+
 	server, client := net.Pipe()
 
 	remoteServer, remoteClient := net.Pipe()
@@ -356,6 +398,8 @@ func TestHandleClientBiDirectional(t *testing.T) {
 }
 
 func TestExtractPath(t *testing.T) {
+	t.Parallel()
+
 	expectedPath := "/tmp/foo.sock"
 
 	p, err := extractPath(fmt.Sprintf("unix://%s", expectedPath))
@@ -369,12 +413,16 @@ func TestExtractPath(t *testing.T) {
 }
 
 func TestExtractPathMalformed(t *testing.T) {
+	t.Parallel()
+
 	if _, err := extractPath("ddd\t"); err == nil {
 		t.Fatalf("extracting malformed path should fail")
 	}
 }
 
 func TestExtractPathTCP(t *testing.T) {
+	t.Parallel()
+
 	if _, err := extractPath("tcp://localhost:25"); err == nil {
 		t.Fatalf("extracting path with unsupported scheme should fail")
 	}
@@ -382,6 +430,8 @@ func TestExtractPathTCP(t *testing.T) {
 
 // randomUnixSocket() tests.
 func TestRandomUnixSocket(t *testing.T) {
+	t.Parallel()
+
 	d := newConnected("localhost:80", nil).(*sshConnected)
 
 	unixAddr, err := d.randomUnixSocket()
@@ -399,6 +449,8 @@ func TestRandomUnixSocket(t *testing.T) {
 }
 
 func TestRandomUnixSocketBadUUID(t *testing.T) {
+	t.Parallel()
+
 	d := newConnected("localhost:80", nil).(*sshConnected)
 	d.uuid = func() (uuid.UUID, error) {
 		return uuid.UUID{}, fmt.Errorf("happened")
@@ -411,6 +463,8 @@ func TestRandomUnixSocketBadUUID(t *testing.T) {
 
 // forwardConnection() tests.
 func TestForwardConnection(t *testing.T) {
+	t.Parallel()
+
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("unable to listen on random TCP port: %v", err)
@@ -451,6 +505,8 @@ func TestForwardConnection(t *testing.T) {
 }
 
 func TestForwardConnectionBadType(t *testing.T) {
+	t.Parallel()
+
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("unable to listen on random TCP port: %v", err)
@@ -476,6 +532,8 @@ func TestForwardConnectionBadType(t *testing.T) {
 }
 
 func TestForwardConnectionClosedListener(t *testing.T) {
+	t.Parallel()
+
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("unable to listen on random TCP port: %v", err)
@@ -498,7 +556,16 @@ func TestForwardConnectionClosedListener(t *testing.T) {
 }
 
 // Connect() tests.
+//
+// This test may access SSHAuthSockEnv environment variable,
+// which is global variable, so to keep things stable, don't run it in parallel.
+//
+//nolint:paralleltest
 func TestConnect(t *testing.T) {
+	if err := os.Unsetenv(SSHAuthSockEnv); err != nil {
+		t.Fatalf("failed unsetting environment variable %q: %v", SSHAuthSockEnv, err)
+	}
+
 	c := &Config{
 		Address:           "localhost",
 		User:              "root",
@@ -526,7 +593,15 @@ func TestConnect(t *testing.T) {
 	}
 }
 
+// This test may access SSHAuthSockEnv environment variable,
+// which is global variable, so to keep things stable, don't run it in parallel.
+//
+//nolint:paralleltest
 func TestConnectFail(t *testing.T) {
+	if err := os.Unsetenv(SSHAuthSockEnv); err != nil {
+		t.Fatalf("failed unsetting environment variable %q: %v", SSHAuthSockEnv, err)
+	}
+
 	c := &Config{
 		Address:           "localhost",
 		User:              "root",
@@ -556,6 +631,8 @@ func TestConnectFail(t *testing.T) {
 
 // ForwardTCP() tests.
 func TestForwardTCP(t *testing.T) {
+	t.Parallel()
+
 	d := newConnected("localhost:80", nil).(*sshConnected)
 
 	d.listener = func(n, a string) (net.Listener, error) {
@@ -573,6 +650,8 @@ func TestForwardTCP(t *testing.T) {
 }
 
 func TestForwardTCPFailListen(t *testing.T) {
+	t.Parallel()
+
 	d := newConnected("localhost:80", nil).(*sshConnected)
 
 	d.listener = func(n, a string) (net.Listener, error) {
@@ -585,6 +664,8 @@ func TestForwardTCPFailListen(t *testing.T) {
 }
 
 func TestForwardTCPValidateAddress(t *testing.T) {
+	t.Parallel()
+
 	d := newConnected("localhost:80", nil).(*sshConnected)
 
 	d.listener = func(n, a string) (net.Listener, error) {
@@ -598,6 +679,8 @@ func TestForwardTCPValidateAddress(t *testing.T) {
 
 // ForwardUnixSocket() tests.
 func TestForwardUnixSocketNoRandomUnixSocket(t *testing.T) {
+	t.Parallel()
+
 	d := newConnected("localhost:80", nil).(*sshConnected)
 
 	d.uuid = func() (uuid.UUID, error) {
@@ -610,6 +693,8 @@ func TestForwardUnixSocketNoRandomUnixSocket(t *testing.T) {
 }
 
 func TestForwardUnixSocketCantListen(t *testing.T) {
+	t.Parallel()
+
 	d := newConnected("localhost:80", nil).(*sshConnected)
 
 	d.listener = func(n, a string) (net.Listener, error) {
@@ -622,6 +707,8 @@ func TestForwardUnixSocketCantListen(t *testing.T) {
 }
 
 func TestForwardUnixSocketBadPath(t *testing.T) {
+	t.Parallel()
+
 	d := newConnected("localhost:80", nil).(*sshConnected)
 
 	if _, err := d.ForwardUnixSocket("foo\t"); err == nil {
@@ -630,6 +717,8 @@ func TestForwardUnixSocketBadPath(t *testing.T) {
 }
 
 func TestForwardUnixSocket(t *testing.T) {
+	t.Parallel()
+
 	d := newConnected("localhost:80", nil).(*sshConnected)
 
 	if _, err := d.ForwardUnixSocket("unix:///foo"); err != nil {
@@ -638,6 +727,8 @@ func TestForwardUnixSocket(t *testing.T) {
 }
 
 func TestForwardUnixSocketEnsureUnique(t *testing.T) {
+	t.Parallel()
+
 	d := newConnected("localhost:80", nil).(*sshConnected)
 
 	a, err := d.ForwardUnixSocket("unix:///foo")
@@ -655,6 +746,10 @@ func TestForwardUnixSocketEnsureUnique(t *testing.T) {
 	}
 }
 
+// This test may access SSHAuthSockEnv environment variable,
+// which is global variable, so to keep things stable, don't run it in parallel.
+//
+//nolint:paralleltest
 func TestNewBadSSHAgentEnv(t *testing.T) {
 	if err := os.Setenv(SSHAuthSockEnv, "foo"); err != nil {
 		t.Fatalf("failed setting environment variable %q: %v", SSHAuthSockEnv, err)
@@ -675,6 +770,8 @@ func TestNewBadSSHAgentEnv(t *testing.T) {
 }
 
 func TestNewSSHAgent(t *testing.T) {
+	t.Parallel()
+
 	a := agent.NewKeyring()
 
 	addr := &net.UnixAddr{
@@ -721,6 +818,8 @@ func TestNewSSHAgent(t *testing.T) {
 }
 
 func TestNewSSHAgentWrongSocket(t *testing.T) {
+	t.Parallel()
+
 	addr := &net.UnixAddr{
 		Name: "@bar",
 		Net:  "unix",

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -15,8 +15,6 @@ import (
 )
 
 func getClientConfig(t *testing.T) *client.Config {
-	t.Parallel()
-
 	p := &pki.PKI{
 		Kubernetes: &pki.Kubernetes{},
 	}
@@ -33,6 +31,8 @@ func getClientConfig(t *testing.T) *client.Config {
 }
 
 func TestToHostConfiguredContainer(t *testing.T) {
+	t.Parallel()
+
 	cc := getClientConfig(t)
 
 	kk := &Kubelet{
@@ -208,6 +208,8 @@ func TestKubeletValidate(t *testing.T) { //nolint:funlen
 		tc := tc
 
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+
 			cc := getClientConfig(t)
 
 			k := &Kubelet{
@@ -229,6 +231,8 @@ func TestKubeletValidate(t *testing.T) { //nolint:funlen
 }
 
 func TestKubeletIncludeExtraMounts(t *testing.T) {
+	t.Parallel()
+
 	em := containertypes.Mount{
 		Source: "/tmp/",
 		Target: "/foo",

--- a/pkg/kubelet/pool_test.go
+++ b/pkg/kubelet/pool_test.go
@@ -58,6 +58,8 @@ kubelets:
 
 // New() tests.
 func TestPoolNewValidate(t *testing.T) {
+	t.Parallel()
+
 	y := `
 ssh:
   address: localhost
@@ -78,11 +80,15 @@ kubelets:
 
 // FromYaml() tests.
 func TestPoolFromYaml(t *testing.T) {
+	t.Parallel()
+
 	GetPool(t)
 }
 
 // StateToYaml() tests.
 func TestPoolStateToYAML(t *testing.T) {
+	t.Parallel()
+
 	p := GetPool(t)
 
 	if _, err := p.StateToYaml(); err != nil {
@@ -92,6 +98,8 @@ func TestPoolStateToYAML(t *testing.T) {
 
 // CheckCurrentState() tests.
 func TestPoolCheckCurrentState(t *testing.T) {
+	t.Parallel()
+
 	p := GetPool(t)
 
 	if err := p.CheckCurrentState(); err != nil {
@@ -101,6 +109,8 @@ func TestPoolCheckCurrentState(t *testing.T) {
 
 // Containers() tests.
 func TestPoolContainers(t *testing.T) {
+	t.Parallel()
+
 	p := GetPool(t)
 
 	if c := p.Containers(); c == nil {
@@ -110,6 +120,8 @@ func TestPoolContainers(t *testing.T) {
 
 // Deploy() tests.
 func TestPoolDeploy(t *testing.T) {
+	t.Parallel()
+
 	p := GetPool(t)
 
 	if err := p.Deploy(); err == nil {
@@ -118,6 +130,8 @@ func TestPoolDeploy(t *testing.T) {
 }
 
 func TestPoolPropagateExtraMounts(t *testing.T) {
+	t.Parallel()
+
 	p := GetPool(t).(*pool)
 
 	found := false
@@ -150,6 +164,8 @@ func TestPoolPropagateExtraMounts(t *testing.T) {
 }
 
 func TestPoolPKIIntegration(t *testing.T) {
+	t.Parallel()
+
 	pk := &pki.PKI{
 		Kubernetes: &pki.Kubernetes{},
 	}
@@ -186,6 +202,8 @@ func TestPoolPKIIntegration(t *testing.T) {
 }
 
 func TestPoolNoKubelets(t *testing.T) {
+	t.Parallel()
+
 	pk := &pki.PKI{
 		Kubernetes: &pki.Kubernetes{},
 	}

--- a/pkg/kubernetes/client/client_test.go
+++ b/pkg/kubernetes/client/client_test.go
@@ -5,6 +5,8 @@ import (
 )
 
 func TestCheckNodeExistsFakeKubeconfig(t *testing.T) {
+	t.Parallel()
+
 	kubeconfig := GetKubeconfig(t)
 
 	c, err := NewClient([]byte(kubeconfig))
@@ -24,6 +26,8 @@ func TestCheckNodeExistsFakeKubeconfig(t *testing.T) {
 }
 
 func TestWaitForNodeFakeKubeconfig(t *testing.T) {
+	t.Parallel()
+
 	kubeconfig := GetKubeconfig(t)
 
 	c, err := NewClient([]byte(kubeconfig))
@@ -37,6 +41,8 @@ func TestWaitForNodeFakeKubeconfig(t *testing.T) {
 }
 
 func TestLabelNodeFakeKubeconfig(t *testing.T) {
+	t.Parallel()
+
 	kubeconfig := GetKubeconfig(t)
 
 	c, err := NewClient([]byte(kubeconfig))
@@ -55,6 +61,8 @@ func TestLabelNodeFakeKubeconfig(t *testing.T) {
 
 // Ping() tests.
 func TestPingFakeKubeconfig(t *testing.T) {
+	t.Parallel()
+
 	kubeconfig := GetKubeconfig(t)
 
 	c, err := NewClient([]byte(kubeconfig))
@@ -75,6 +83,8 @@ func TestPingFakeKubeconfig(t *testing.T) {
 
 // CheckNodeReady() tests.
 func TestCheckNodeReadyFakeKubeconfig(t *testing.T) {
+	t.Parallel()
+
 	kubeconfig := GetKubeconfig(t)
 
 	c, err := NewClient([]byte(kubeconfig))

--- a/pkg/kubernetes/client/clientset_test.go
+++ b/pkg/kubernetes/client/clientset_test.go
@@ -5,6 +5,8 @@ import (
 )
 
 func TestNewClientset(t *testing.T) {
+	t.Parallel()
+
 	kubeconfig := GetKubeconfig(t)
 
 	if _, err := NewClientset([]byte(kubeconfig)); err != nil {

--- a/pkg/kubernetes/client/getter_test.go
+++ b/pkg/kubernetes/client/getter_test.go
@@ -5,6 +5,8 @@ import (
 )
 
 func TestGetter(t *testing.T) {
+	t.Parallel()
+
 	kubeconfig := GetKubeconfig(t)
 
 	g, err := NewGetter([]byte(kubeconfig))

--- a/pkg/kubernetes/client/kubeconfig_test.go
+++ b/pkg/kubernetes/client/kubeconfig_test.go
@@ -46,6 +46,8 @@ clientKey: |
 
 // ToYAMLString() tests.
 func TestUnmarshal(t *testing.T) {
+	t.Parallel()
+
 	if kubeconfig := GetKubeconfig(t); kubeconfig == "" {
 		t.Fatalf("Generated kubeconfig shouldn't be empty")
 	}
@@ -168,6 +170,8 @@ func TestToYAMLStringNew(t *testing.T) { //nolint:funlen
 }
 
 func TestToYAMLStringValidate(t *testing.T) {
+	t.Parallel()
+
 	pki := utiltest.GeneratePKI(t)
 
 	c := &Config{

--- a/pkg/pki/etcd.go
+++ b/pkg/pki/etcd.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	// EtcdCACN is a default CN for etcd CA certificate, as recommended by
-	// https://kubernetes.io/docs/setup/best-practices/certificates/.
+	// the https://kubernetes.io/docs/setup/best-practices/certificates/.
 	EtcdCACN = "etcd-ca"
 )
 

--- a/pkg/pki/pki_test.go
+++ b/pkg/pki/pki_test.go
@@ -254,6 +254,8 @@ func TestGenerateEtcdCopyServers(t *testing.T) {
 }
 
 func TestDecodeKeypair(t *testing.T) {
+	t.Parallel()
+
 	ca := &pki.Certificate{
 		PrivateKey: "foo",
 	}
@@ -269,6 +271,8 @@ func TestDecodeKeypair(t *testing.T) {
 }
 
 func TestValidateRSABits(t *testing.T) {
+	t.Parallel()
+
 	c := &pki.Certificate{
 		ValidityDuration: "24h",
 	}

--- a/pkg/pki/privatekey_test.go
+++ b/pkg/pki/privatekey_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestPrivateKeyParse(t *testing.T) {
+	t.Parallel()
+
 	cases := map[string]struct {
 		key string
 		err bool
@@ -42,6 +44,8 @@ aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQo=
 		c := c
 
 		t.Run(n, func(t *testing.T) {
+			t.Parallel()
+
 			err := pki.ValidatePrivateKey(c.key)
 
 			if c.err && err == nil {

--- a/pkg/types/certificate_test.go
+++ b/pkg/types/certificate_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestCertificateParse(t *testing.T) {
+	t.Parallel()
+
 	type Foo struct {
 		Bar Certificate `json:"bar"`
 	}
@@ -34,6 +36,8 @@ func TestCertificateParse(t *testing.T) {
 		c := c
 
 		t.Run(n, func(t *testing.T) {
+			t.Parallel()
+
 			bar := &Foo{}
 
 			err := yaml.Unmarshal([]byte(c.YAML), bar)
@@ -58,6 +62,8 @@ func TestCertificateParse(t *testing.T) {
 }
 
 func TestCertificatePickNil(t *testing.T) {
+	t.Parallel()
+
 	var c Certificate
 
 	d := Certificate("bar")
@@ -69,6 +75,8 @@ func TestCertificatePickNil(t *testing.T) {
 }
 
 func TestCertificatePick(t *testing.T) {
+	t.Parallel()
+
 	d := Certificate("foo")
 	e := Certificate("baz")
 

--- a/pkg/types/privatekey_test.go
+++ b/pkg/types/privatekey_test.go
@@ -16,6 +16,8 @@ type Foo struct {
 }
 
 func TestPrivateKeyParse(t *testing.T) {
+	t.Parallel()
+
 	cases := map[string]struct {
 		YAML  string
 		Error bool
@@ -34,6 +36,8 @@ func TestPrivateKeyParse(t *testing.T) {
 		c := c
 
 		t.Run(n, func(t *testing.T) {
+			t.Parallel()
+
 			bar := &Foo{}
 
 			err := yaml.Unmarshal([]byte(c.YAML), bar)
@@ -58,6 +62,8 @@ func TestPrivateKeyParse(t *testing.T) {
 }
 
 func TestParsePrivateKeyPKCS1(t *testing.T) {
+	t.Parallel()
+
 	d := fmt.Sprintf("bar: |\n%s", util.Indent(strings.TrimSpace(utiltest.GeneratePKCS1PrivateKey(t)), "  "))
 
 	if err := yaml.Unmarshal([]byte(d), &Foo{}); err != nil {
@@ -66,6 +72,8 @@ func TestParsePrivateKeyPKCS1(t *testing.T) {
 }
 
 func TestParsePrivateKeyEC(t *testing.T) {
+	t.Parallel()
+
 	d := fmt.Sprintf("bar: |\n%s", util.Indent(strings.TrimSpace(utiltest.GenerateECPrivateKey(t)), "  "))
 
 	if err := yaml.Unmarshal([]byte(d), &Foo{}); err != nil {
@@ -74,12 +82,16 @@ func TestParsePrivateKeyEC(t *testing.T) {
 }
 
 func TestParsePrivateKeyBad(t *testing.T) {
+	t.Parallel()
+
 	if err := parsePrivateKey([]byte("notpem")); err == nil {
 		t.Fatalf("parsing not PEM format should fail")
 	}
 }
 
 func TestPrivateKeyPickNil(t *testing.T) {
+	t.Parallel()
+
 	var c PrivateKey
 
 	d := PrivateKey("bar")
@@ -91,6 +103,8 @@ func TestPrivateKeyPickNil(t *testing.T) {
 }
 
 func TestPrivateKeyPick(t *testing.T) {
+	t.Parallel()
+
 	d := PrivateKey("foo")
 	e := PrivateKey("baz")
 


### PR DESCRIPTION
This adds new linter which checks if all unit tests are run in parallel,
so this is added as well.

Some tests, e.g. ones which test using environment variables cannot run
in parallel, so the linter is explicitly disabled there with a comment.

Overall, it seems adding t.Parallel() cuts unit test execution time by
~2 seconds (~17s -> ~15s) and also makes sure that tests are independent
and exposes code which might be racey, so I think it make sense to add
it.

One rule from 'paralleltest' linter has been disabled, as it doesn't
make much sense. It has been reported here:
https://github.com/kunwardeep/paralleltest/issues/8

Also, now we add '--sort-output' flag to 'golangci-lint run' invokation,
so returned warnings are printed in a stable manner.

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>