### PR TITLE
pkg/container: fix missing newline in fmt.Printf

### DIFF
--- a/pkg/container/hostconfiguredcontainer.go
+++ b/pkg/container/hostconfiguredcontainer.go
@@ -288,7 +288,7 @@ func (m *hostConfiguredContainer) withConfigurationContainer(action func() error
 
 	defer func() {
 		if err := m.removeConfigurationContainer(); err != nil {
-			fmt.Printf("Removing configuration container failed: %v", err)
+			fmt.Printf("Removing configuration container failed: %v\n", err)
 		}
 	}()
 


### PR DESCRIPTION
Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>