### PR TITLE
.golangci.yml: re-enable scopelint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -62,8 +62,6 @@ linters:
     # This linter has been deprecated.
     - maligned
     # This linter has been deprecated.
-    - scopelint
-    # This linter has been deprecated.
     - golint
   enable:
     - asciicheck
@@ -113,6 +111,7 @@ linters:
     - promlinter
     - revive
     - rowserrcheck
+    - scopelint
     - sqlclosecheck
     - structcheck
     - stylecheck


### PR DESCRIPTION
Even though it's deprecated, currently there is no alternative with the
same features available.

See https://github.com/kyoh86/looppointer/issues/8 for more details.

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>