### PR TITLE
libvirt: update libvirt provider to latest version

### DIFF
--- a/libvirt/versions.tf
+++ b/libvirt/versions.tf
@@ -7,8 +7,8 @@ terraform {
       version = "3.0.0"
     }
     libvirt = {
-      source  = "dmacvicar/libvirt"
-      version = "0.6.3"
+      source  = "invidian/libvirt"
+      version = "0.6.10-rc1"
     }
     ct = {
       source  = "poseidon/ct"


### PR DESCRIPTION
Which use go-libvirt. Custom version to include
https://github.com/dmacvicar/terraform-provider-libvirt/pull/867.

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>