### PR TITLE
Update to Kubernetes v1.24.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,8 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - uses: actions/checkout@v2
+    - name: Setup containerd
+      uses: crazy-max/ghaction-setup-containerd@v1.3.0
     - name: Fetch dependencies and configure tests
       run: |
         docker-compose -f e2e/docker-compose.yml up -d
@@ -87,7 +89,6 @@ jobs:
           nodesCIDR: 172.17.0.0/24
           nodeSSHPort: 2222
           workersCount: 0
-          containerRuntime: docker
           cidrIPsOffset: 1
           kubeletExtraArgs: [--fail-swap-on=false]
           cgroupDriver: cgroupfs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,9 @@ jobs:
           nodeSSHPort: 2222
           workersCount: 0
           cidrIPsOffset: 1
-          kubeletExtraArgs: [--fail-swap-on=false]
+          kubeletExtraArgs:
+          - --fail-swap-on=false
+          - --container-runtime-endpoint=unix:///run/containerd/containerd.sock
           cgroupDriver: cgroupfs
         EOF
         helm repo add flexkube https://flexkube.github.io/charts/

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -23,3 +23,21 @@ rules:
     message: When wrapping errors, %w must be preceded by space.
     languages: [go]
     severity: ERROR
+  - id: files-must-not-have-trailing-whitespace
+    patterns:
+      - pattern-regex: '[[:blank:]]$'
+    message: Files must not have any trailing whitespace.
+    languages: [generic]
+    severity: ERROR
+  - id: files-must-not-have-trailing-newlines
+    patterns:
+      - pattern-regex: '\n\n\Z'
+    message: Files must not have any trailing newlines.
+    languages: [generic]
+    severity: ERROR
+  - id: all-lines-must-end-with-newline
+    patterns:
+      - pattern-regex: '\S\z'
+    message: All lines must end with newline.
+    languages: [generic]
+    severity: ERROR

--- a/Makefile
+++ b/Makefile
@@ -146,14 +146,14 @@ test-cover-browse: test-cover cover-browse
 .PHONY: test-e2e-run
 test-e2e-run:
 	helm repo update
-	env $(TERRAFORM_ENV) $(GOTEST) -v -tags e2e ./e2e/
+	env $(TERRAFORM_ENV) $(GOTEST) -v -tags e2e -count 1 ./e2e/
 
 .PHONY: test-e2e
 test-e2e: test-e2e-run
 
 .PHONY: test-local-apply
 test-local-apply:
-	env $(TERRAFORM_ENV) $(GOTEST) -v -tags e2e ./local-testing/
+	env $(TERRAFORM_ENV) $(GOTEST) -v -tags e2e -count 1 ./local-testing/
 
 .PHONY: test-conformance
 test-conformance:SHELL=/bin/bash

--- a/Makefile
+++ b/Makefile
@@ -340,4 +340,4 @@ terraform-fmt:
 .PHONY: semgrep
 semgrep: SEMGREP_BIN=semgrep
 semgrep:
-	@if ! which $(SEMGREP_BIN) >/dev/null 2>&1; then echo "$(SEMGREP_BIN) binary not found, skipping extra linting"; else $(SEMGREP_BIN); fi
+	@if ! which $(SEMGREP_BIN) >/dev/null 2>&1; then echo "$(SEMGREP_BIN) binary not found, skipping extra linting"; else $(SEMGREP_BIN) --error; fi

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -100,15 +100,15 @@ func defaultE2EConfig(t *testing.T) e2eConfig {
 		Charts: charts{
 			KubeAPIServer: chart{
 				Source:  "flexkube/kube-apiserver",
-				Version: "0.3.20",
+				Version: "0.4.0",
 			},
 			Kubernetes: chart{
 				Source:  "flexkube/kubernetes",
-				Version: "0.4.22",
+				Version: "0.5.0",
 			},
 			KubeProxy: chart{
 				Source:  "flexkube/kube-proxy",
-				Version: "0.3.20",
+				Version: "0.4.0",
 			},
 			TLSBootstrapping: chart{
 				Source:  "flexkube/tls-bootstrapping",

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -49,25 +49,17 @@ type charts struct {
 }
 
 type e2eConfig struct {
-	ControllersCount  int              `json:"controllersCount"`
-	NodesCIDR         string           `json:"nodesCIDR"`
-	WorkersCount      int              `json:"workersCount"`
-	APIPort           int              `json:"apiPort"`
-	NodeSSHPort       int              `json:"nodeSSHPort"`
-	SSHPrivateKeyPath string           `json:"sshPrivatekeyPath"`
-	Charts            charts           `json:"charts"`
-	ContainerRuntime  ContainerRuntime `json:"containerRuntime"`
-	CIDRIPsOffset     int              `json:"cidrIPsOffset"`
-	KubeletExtraArgs  []string         `json:"kubeletExtraArgs"`
-	CgroupDriver      string           `json:"cgroupDriver"`
+	ControllersCount  int      `json:"controllersCount"`
+	NodesCIDR         string   `json:"nodesCIDR"`
+	WorkersCount      int      `json:"workersCount"`
+	APIPort           int      `json:"apiPort"`
+	NodeSSHPort       int      `json:"nodeSSHPort"`
+	SSHPrivateKeyPath string   `json:"sshPrivatekeyPath"`
+	Charts            charts   `json:"charts"`
+	CIDRIPsOffset     int      `json:"cidrIPsOffset"`
+	KubeletExtraArgs  []string `json:"kubeletExtraArgs"`
+	CgroupDriver      string   `json:"cgroupDriver"`
 }
-
-type ContainerRuntime string
-
-const (
-	Docker     ContainerRuntime = "docker"
-	Containerd ContainerRuntime = "containerd"
-)
 
 func parseInt(t *testing.T, envVar string, defaultValue int) int {
 	t.Helper()
@@ -103,7 +95,6 @@ func defaultE2EConfig(t *testing.T) e2eConfig {
 		APIPort:           8443,
 		NodeSSHPort:       22,
 		SSHPrivateKeyPath: "/root/.ssh/id_rsa",
-		ContainerRuntime:  Containerd,
 		CIDRIPsOffset:     2,
 		CgroupDriver:      "systemd",
 		Charts: charts{
@@ -140,10 +131,13 @@ func defaultE2EConfig(t *testing.T) e2eConfig {
 				Version: "0.4.16",
 			},
 		},
+		KubeletExtraArgs: []string{
+			"--container-runtime-endpoint=unix:///run/containerd/containerd.sock",
+		},
 	}
 }
 
-//nolint:funlen,gocognit,paralleltest,cyclop,gocyclo,maintidx // Test function, splitting it decreases readability.
+//nolint:funlen,gocognit,paralleltest,cyclop,maintidx // Test function, splitting it decreases readability.
 func TestE2e(t *testing.T) {
 	testConfig := defaultE2EConfig(t)
 
@@ -262,33 +256,22 @@ func TestE2e(t *testing.T) {
 
 	hairpinMode := "hairpin-veth"
 
-	kubeletExtraMounts := []types.Mount{}
+	kubeletExtraMounts := []types.Mount{
+		{
+			Source: "/run/containerd/",
+			Target: "/run/containerd",
+		},
+		{
+			Source: "/var/lib/containerd/",
+			Target: "/var/lib/containerd",
+		},
+	}
 
 	if testConfig.CgroupDriver == "systemd" {
 		kubeletExtraMounts = append(kubeletExtraMounts, types.Mount{
 			Source: "/run/systemd/",
 			Target: "/run/systemd",
 		})
-	}
-
-	kubeletExtraArgs := testConfig.KubeletExtraArgs
-
-	if testConfig.ContainerRuntime == Containerd {
-		kubeletExtraMounts = append(kubeletExtraMounts, []types.Mount{
-			{
-				Source: "/run/containerd/",
-				Target: "/run/containerd",
-			},
-			{
-				Source: "/var/lib/containerd/",
-				Target: "/var/lib/containerd",
-			},
-		}...)
-
-		kubeletExtraArgs = append(kubeletExtraArgs, []string{
-			"--container-runtime=remote",
-			"--container-runtime-endpoint=unix:///run/containerd/containerd.sock",
-		}...)
 	}
 
 	// Generate PKI.
@@ -374,7 +357,7 @@ func TestE2e(t *testing.T) {
 				SSH:         sshConfig,
 				Kubelets:    controllerKubelets,
 				ExtraMounts: kubeletExtraMounts,
-				ExtraArgs:   kubeletExtraArgs,
+				ExtraArgs:   testConfig.KubeletExtraArgs,
 			},
 		},
 		State: &flexkube.ResourceState{},
@@ -405,7 +388,7 @@ func TestE2e(t *testing.T) {
 			SSH:         sshConfig,
 			Kubelets:    workerKubelets,
 			ExtraMounts: kubeletExtraMounts,
-			ExtraArgs:   kubeletExtraArgs,
+			ExtraArgs:   testConfig.KubeletExtraArgs,
 		}
 
 		resource.APILoadBalancerPools["workers"] = &apiloadbalancer.APILoadBalancers{

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -284,10 +284,6 @@ func TestE2e(t *testing.T) {
 				Source: "/var/lib/containerd/",
 				Target: "/var/lib/containerd",
 			},
-			{
-				Source: "/run/torcx/unpack/docker/bin/containerd-shim-runc-v2",
-				Target: "/usr/bin/containerd-shim-runc-v2",
-			},
 		}...)
 
 		kubeletExtraArgs = append(kubeletExtraArgs, []string{

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -260,7 +260,6 @@ func TestE2e(t *testing.T) {
 	bootstrapTokenID := "64vxqx"
 	bootstrapTokenSecret := "z95f5ng9sek5i40v" // #nosec:G101
 
-	networkPlugin := "cni"
 	hairpinMode := "hairpin-veth"
 
 	kubeletExtraMounts := []types.Mount{}
@@ -354,7 +353,6 @@ func TestE2e(t *testing.T) {
 				},
 				WaitForNodeReady: true,
 				CgroupDriver:     testConfig.CgroupDriver,
-				NetworkPlugin:    networkPlugin,
 				HairpinMode:      hairpinMode,
 				VolumePluginDir:  "/var/lib/kubelet/volumeplugins",
 				ClusterDNSIPs:    []string{"11.0.0.10"},
@@ -390,7 +388,6 @@ func TestE2e(t *testing.T) {
 			},
 			WaitForNodeReady: true,
 			CgroupDriver:     testConfig.CgroupDriver,
-			NetworkPlugin:    networkPlugin,
 			HairpinMode:      hairpinMode,
 			VolumePluginDir:  "/var/lib/kubelet/volumeplugins",
 			ClusterDNSIPs:    []string{"11.0.0.10"},

--- a/pkg/controlplane/kube-apiserver.go
+++ b/pkg/controlplane/kube-apiserver.go
@@ -176,8 +176,6 @@ func (k *kubeAPIServer) args() []string {
 		"--enable-bootstrap-token-auth=true",
 		// Allow user to configure service CIDR, so it does not conflict with host nor pods CIDRs.
 		fmt.Sprintf("--service-cluster-ip-range=%s", k.serviceCIDR),
-		// To disable access without authentication.
-		"--insecure-port=0",
 		// Since we will run self-hosted K8s, pods like kube-proxy must run as privileged containers, so we must allow them.
 		"--allow-privileged=true",
 		// Enable RBAC for generic RBAC and Node, so kubelets can use special permissions.
@@ -210,8 +208,6 @@ func (k *kubeAPIServer) args() []string {
 		// - NodeRestriction for extra protection against rogue cluster nodes.
 		// - PodSecurityPolicy for PSP support.
 		"--enable-admission-plugins=NodeRestriction,PodSecurityPolicy",
-		// To limit memory consumption of bootstrap controlplane, limit it to 512 MB.
-		"--target-ram-mb=512",
 		// Use SO_REUSEPORT, so multiple instances can run on the same controller for smooth upgrades.
 		"--permit-port-sharing=true",
 		// New flags required for TokenRequest feature.

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -7,19 +7,19 @@ const (
 
 	// KubeAPIServerImage points to a default Docker image, which will be used for
 	// running kube-apiserver.
-	KubeAPIServerImage = "k8s.gcr.io/kube-apiserver:v1.23.6"
+	KubeAPIServerImage = "k8s.gcr.io/kube-apiserver:v1.24.0"
 
 	// KubeControllerManagerImage points to a default Docker image, which will be used for
 	// running kube-apiserver.
-	KubeControllerManagerImage = "k8s.gcr.io/kube-controller-manager:v1.23.6"
+	KubeControllerManagerImage = "k8s.gcr.io/kube-controller-manager:v1.24.0"
 
 	// KubeSchedulerImage points to a default Docker image, which will be used for
 	// running kube-apiserver.
-	KubeSchedulerImage = "k8s.gcr.io/kube-scheduler:v1.23.6"
+	KubeSchedulerImage = "k8s.gcr.io/kube-scheduler:v1.24.0"
 
 	// KubeletImage points to a default Docker image, which will be used for
 	// running kube-apiserver.
-	KubeletImage = "quay.io/flexkube/kubelet:v1.23.6"
+	KubeletImage = "quay.io/flexkube/kubelet:v1.24.0"
 
 	// HAProxyImage is a default container image for APILoadBalancer.
 	HAProxyImage = "haproxy:2.5.6-alpine"

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -22,7 +22,7 @@ const (
 	KubeletImage = "quay.io/flexkube/kubelet:v1.23.6"
 
 	// HAProxyImage is a default container image for APILoadBalancer.
-	HAProxyImage = "haproxy:2.5.5-alpine"
+	HAProxyImage = "haproxy:2.5.6-alpine"
 
 	// DockerAPIVersion is a default API version used when talking to Docker runtime.
 	DockerAPIVersion = "v1.38"

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -41,7 +41,6 @@ func TestToHostConfiguredContainer(t *testing.T) {
 	testKubelet := &kubelet.Kubelet{
 		BootstrapConfig:         clientConfig,
 		Name:                    "fooz",
-		NetworkPlugin:           "cni",
 		VolumePluginDir:         "/var/lib/kubelet/volumeplugins",
 		KubernetesCACertificate: types.Certificate(utiltest.GenerateX509Certificate(t)),
 		Host: host.Host{
@@ -174,30 +173,6 @@ func TestKubeletValidate(t *testing.T) { //nolint:funlen,cyclop // There are jus
 			},
 		},
 		{
-			MutationF: func(k *kubelet.Kubelet) { k.PodCIDR = "foo" },
-			TestF: func(t *testing.T, err error) { //nolint:thelper // Actual test code.
-				if err == nil {
-					t.Fatalf("Validation of kubelet should fail when network plugin is 'cni' and pod CIDR is set")
-				}
-			},
-		},
-		{
-			MutationF: func(k *kubelet.Kubelet) { k.NetworkPlugin = kubelet.KubenetNetworkPlugin },
-			TestF: func(t *testing.T, err error) { //nolint:thelper // Actual test code.
-				if err == nil {
-					t.Fatalf("Validation of kubelet should fail when network plugin is 'kubelet' and pod CIDR is empty")
-				}
-			},
-		},
-		{
-			MutationF: func(k *kubelet.Kubelet) { k.NetworkPlugin = "doh" },
-			TestF: func(t *testing.T, err error) { //nolint:thelper // Actual test code.
-				if err == nil {
-					t.Fatalf("Validation of kubelet should fail when network plugin is invalid")
-				}
-			},
-		},
-		{
 			MutationF: func(k *kubelet.Kubelet) { k.Host.DirectConfig = nil },
 			TestF: func(t *testing.T, err error) { //nolint:thelper // Actual test code.
 				if err == nil {
@@ -218,7 +193,6 @@ func TestKubeletValidate(t *testing.T) { //nolint:funlen,cyclop // There are jus
 			testKubelet := &kubelet.Kubelet{
 				BootstrapConfig:         clientConfig,
 				Name:                    "foo",
-				NetworkPlugin:           "cni",
 				VolumePluginDir:         "/foo",
 				KubernetesCACertificate: types.Certificate(utiltest.GenerateX509Certificate(t)),
 				Host: host.Host{
@@ -246,7 +220,6 @@ func TestKubeletIncludeExtraMounts(t *testing.T) {
 	testKubeletConfig := &kubelet.Kubelet{
 		BootstrapConfig:         clientConfig,
 		Name:                    "foo",
-		NetworkPlugin:           "cni",
 		VolumePluginDir:         "/var/lib/kubelet/volumeplugins",
 		KubernetesCACertificate: types.Certificate(utiltest.GenerateX509Certificate(t)),
 		Host: host.Host{
@@ -299,7 +272,6 @@ func Test_Kubelet_container_definition_does_include_defined_extra_flags(t *testi
 	testKubeletConfig := &kubelet.Kubelet{
 		BootstrapConfig:         clientConfig,
 		Name:                    "foo",
-		NetworkPlugin:           "cni",
 		VolumePluginDir:         "/var/lib/kubelet/volumeplugins",
 		KubernetesCACertificate: types.Certificate(utiltest.GenerateX509Certificate(t)),
 		Host: host.Host{

--- a/pkg/kubelet/pool.go
+++ b/pkg/kubelet/pool.go
@@ -20,8 +20,6 @@ import (
 )
 
 const (
-	// DefaultNetworkPlugin is a default NetworkPlugin configured for kubelets.
-	DefaultNetworkPlugin = "cni"
 	// DefaultHairpinMode is a default HairpinMode configured for kubelets.
 	DefaultHairpinMode = "hairpin-veth"
 )
@@ -94,10 +92,6 @@ type Pool struct {
 	// CgroupDriver configures cgroup driver to be used by the kubelet. It must be the same
 	// as configured for container runtime used by the kubelet.
 	CgroupDriver string `json:"cgroupDriver,omitempty"`
-
-	// NetworkPlugin defines which network solution should be used by kubelet to assign
-	// IP addresses to the pods. By default, 'cni' is used. Also 'kubelet' is a valid value.
-	NetworkPlugin string `json:"networkPlugin,omitempty"`
 
 	// SystemReserved configures, how much resources kubelet should mark as used by the operating
 	// system.
@@ -192,7 +186,6 @@ func (p *Pool) propagateKubelet(kubelet *Kubelet) {
 	kubelet.PrivilegedLabels = util.PickStringMap(kubelet.PrivilegedLabels, p.PrivilegedLabels)
 	kubelet.Taints = util.PickStringMap(kubelet.Taints, p.Taints)
 	kubelet.CgroupDriver = util.PickString(kubelet.CgroupDriver, p.CgroupDriver)
-	kubelet.NetworkPlugin = util.PickString(kubelet.NetworkPlugin, p.NetworkPlugin, DefaultNetworkPlugin)
 	kubelet.SystemReserved = util.PickStringMap(kubelet.SystemReserved, p.SystemReserved)
 	kubelet.KubeReserved = util.PickStringMap(kubelet.KubeReserved, p.KubeReserved)
 	kubelet.HairpinMode = util.PickString(kubelet.HairpinMode, p.HairpinMode, DefaultHairpinMode)

--- a/pkg/kubelet/pool_test.go
+++ b/pkg/kubelet/pool_test.go
@@ -37,10 +37,8 @@ waitForNodeReady: false
 extraArgs:
 - --baz
 kubelets:
-- networkPlugin: cni
-  name: foo
-- networkPlugin: cni
-  name: bar
+- name: foo
+- name: bar
   extraMounts:
   - source: /doh/
     target: /tmp
@@ -76,8 +74,7 @@ ssh:
   retryInterval: 1s
 volumePluginDir: /var/lib/kubelet/volumeplugins
 kubelets:
-- networkPlugin: cni
-  name: foo
+- name: foo
 `
 
 	if _, err := kubelet.FromYaml([]byte(testConfigRaw)); err == nil {
@@ -241,7 +238,6 @@ func TestPoolPKIIntegration(t *testing.T) {
 			{
 				Name:            "foo",
 				VolumePluginDir: "foo",
-				NetworkPlugin:   "cni",
 			},
 		},
 		PrivilegedLabels: map[string]string{


### PR DESCRIPTION
* Use containerd runtime on CI for e2e tests
* Remove use of removed flags for API server and kubelet
* Remove Docker related kubelet flags and configuration fields
* Remove kubenet related flags and configuration fields

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>