### PR TITLE
pkg/etcd: fix --initial-cluster generation

### DIFF
--- a/pkg/etcd/cluster.go
+++ b/pkg/etcd/cluster.go
@@ -103,7 +103,7 @@ func (c *Cluster) propagateMember(memberName string, memberConfig *MemberConfig)
 
 	for n, m := range c.Members {
 		// If member has no name defined explicitly, use key passed as argument.
-		name := util.PickString(memberConfig.Name, n)
+		name := util.PickString(m.Name, n)
 
 		initialClusterArr = append(initialClusterArr, fmt.Sprintf("%s=https://%s:2380", name, m.PeerAddress))
 		peerCertAllowedCNArr = append(peerCertAllowedCNArr, name)


### PR DESCRIPTION
Introduced in 3c15d05ba0f1d685e34e80ce2e818d83bbc096bf, while fixing
short variable names.

Opening as draft as I need to look over entire 3c15d05ba0f1d685e34e80ce2e818d83bbc096bf to make sure there is no more bugs introduced by it.

Closes #324

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>